### PR TITLE
fixup redis tests; 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --fix .",
     "clean": "rimraf dist/",
     "test": "mocha --recursive --compilers js:babel-register test/*",
-    "dev-test": "LOG_LEVEL=info node --harmony node_modules/mocha/bin/_mocha --grep='tests' --invert --recursive  test"
+    "dev-test": "LOG_LEVEL=info node --harmony node_modules/mocha/bin/_mocha  --recursive  test"
   },
   "author": "Roman Lisagor <roman@lunchbadger.com>",
   "license": "UNLICENSED",
@@ -42,11 +42,13 @@
     "connect-ensure-login": "0.1.1",
     "cors": "2.8.3",
     "express": "4.15.2",
+    "fakeredis": "^2.0.0",
     "http-proxy": "1.16.2",
     "js-yaml": "3.8.3",
     "limiter": "1.1.0",
     "lodash": "4.17.4",
     "minimatch": "3.0.3",
+    "mock-require": "^2.0.2",
     "node-uuid": "1.4.8",
     "npm": "4.5.0",
     "oauth2orize": "1.8.0",

--- a/src/credentials/credential.dao.js
+++ b/src/credentials/credential.dao.js
@@ -14,9 +14,8 @@ module.exports = function(config) {
   function insertScopes(_scopes) {
     let scopes = {};
     if (Array.isArray(_scopes)) {
-      _scopes.forEach(el => scopes[el] = true);
-    } else scopes[_scopes] = true;
-
+      _scopes.forEach(el => scopes[el] = 'true');
+    } else scopes[_scopes] = 'true';
     return db.hmsetAsync(config.credentials.redis.scopePrefix, scopes);
   }
 
@@ -24,7 +23,7 @@ module.exports = function(config) {
     let credentialId = config.credentials.redis.credentialPrefixes[type].concat(':', id);
     let associationPromises;
     Array.isArray(scopes) ? scopes : [ scopes ];
-    associationPromises = scopes.map(scope => db.hsetAsync(config.credentials.redis.scopeCredentialPrefix.concat(':', scope), credentialId, true ));
+    associationPromises = scopes.map(scope => db.hsetAsync(config.credentials.redis.scopeCredentialPrefix.concat(':', scope), credentialId, 'true'));
 
     return Promise.all(associationPromises)
     .catch(() => Promise.reject(new Error('failed to associate credential with scopes in db'))); // TODO: replace with server error
@@ -121,11 +120,11 @@ module.exports = function(config) {
   }
 
   function activateCredential(id, type) {
-    return db.hsetAsync(config.credentials.redis.credentialPrefixes[type].concat(':', id), 'isActive', true);
+    return db.hsetAsync(config.credentials.redis.credentialPrefixes[type].concat(':', id), 'isActive', 'true');
   }
 
   function deactivateCredential(id, type) {
-    return db.hsetAsync(config.credentials.redis.credentialPrefixes[type].concat(':', id), 'isActive', false);
+    return db.hsetAsync(config.credentials.redis.credentialPrefixes[type].concat(':', id), 'isActive', 'false');
   }
 
   function removeCredential(id, type) {

--- a/src/credentials/credential.service.js
+++ b/src/credentials/credential.service.js
@@ -63,7 +63,7 @@ module.exports = function(config) {
         }
 
         credentialConfig = config.credentials.types[type];
-        newCredential = { isActive: true };
+        newCredential = { isActive: 'true' };
 
         return Promise.all([validateNewCredentialScopes(credentialConfig, credentialDetails),
             validateAndHashPassword(credentialConfig, credentialDetails),

--- a/test/applications.test.js
+++ b/test/applications.test.js
@@ -1,3 +1,5 @@
+let mock = require('mock-require');
+mock('redis', require('fakeredis'));
 let should = require('should');
 let config = require('./config.models.js');
 let uuid = require('node-uuid');

--- a/test/credential-service/credentials.test.js
+++ b/test/credential-service/credentials.test.js
@@ -110,7 +110,7 @@ describe('Credential service tests', function () {
       .insertCredential(username, 'basicAuth', _credential)
       .then(function(newCredential) {
         should.exist(newCredential);
-        newCredential.isActive.should.eql(true);
+        newCredential.isActive.should.eql('true');
         done();
       })
       .catch(function(err) {
@@ -125,7 +125,7 @@ describe('Credential service tests', function () {
       .then(function(cred) {
         should.exist(cred);
         should.not.exist(cred.secret);
-        credential.isActive.should.eql(true);
+        credential.isActive.should.eql('true');
         done();
       })
       .catch(function(err) {
@@ -345,7 +345,7 @@ describe('Credential service tests', function () {
         .insertCredential(username, 'oauth', _credential)
         .then(function(newCredential) {
           should.exist(newCredential);
-          newCredential.isActive.should.eql(true);
+          newCredential.isActive.should.eql('true');
           newCredential.scopes.should.exist;
           newCredential.scopes.should.eql(['someScope']);
           newCredential.someProperty.should.eql('propVal');
@@ -465,7 +465,7 @@ describe('Credential service tests', function () {
       .insertCredential(username2, 'oauth', cred)
       .then(function(newCredential) {
         should.exist(newCredential);
-        newCredential.isActive.should.eql(true);
+        newCredential.isActive.should.eql('true');
         newCredential.scopes.should.exist;
         newCredential.scopes.should.eql(['someOtherOne']);
         newCredential.someProperty.should.eql('propVal');


### PR DESCRIPTION
I expect this to be 2 line commit, but it appears that fakeredis does additional check on arguments.
but it have found 1 bug in current implementation.

 the thing is that fakeredis allows only string\number\buffer as value of the key to be send

and the reason for that is that REDIS protocol spec 
https://redis.io/topics/protocol#simple-string-reply

there is no way you pass bool values here. 
so when you do unset({isValid:true})
it will set key isValid to string 'true'

so when you get value back it will not be boolean. 
(By the way you do not do get in the tests you just test that something is sent
see all code with lines newCredential.isActive.should.eql('true');
)

I changed code for scopes and isActive to explicitly set 'true'

but it may be that entire implementation need to be different 
instead of saving each property as redistribution record it may be enough to just store entire JSON.stringify 



