### PR TITLE
Adding circle.yml to test Node 6. Fixes #99.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   node:
     version: 6.11.0
+
+dependencies:
+  pre:
+    - nvm use 6


### PR DESCRIPTION
Currently, this is pinned to the latest Node 6 version.  Hoop-jumping is necessary to test multiple versions, which is up for consideration.