### PR TITLE
Updating bcrypt dependency to 1.0.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-gateway",
-  "version": "0.1.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -243,13 +243,20 @@
       "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
     },
     "bcrypt": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.0.tgz",
-      "integrity": "sha1-6RFw5rhGTmIgDmYYTLVcX6AWGiE=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.2.tgz",
+      "integrity": "sha1-0F/F0iMXPg4o7DgcDwDMJf+vJzY=",
       "requires": {
         "bindings": "1.2.1",
-        "nan": "2.3.5",
-        "node-pre-gyp": "0.6.30"
+        "nan": "2.5.0",
+        "node-pre-gyp": "0.6.32"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz",
+          "integrity": "sha1-qo8eNFMdgH6eJ3VbI0tKbsDBUqg="
+        }
       }
     },
     "bcrypt-pbkdf": {
@@ -4006,7 +4013,8 @@
     "nan": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
-      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg="
+      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
+      "optional": true
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -4026,9 +4034,9 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "node-pre-gyp": {
-      "version": "0.6.30",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.30.tgz",
-      "integrity": "sha1-ZNMHOm9XMANxfM/jDIkCMpe6u6E=",
+      "version": "0.6.32",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
+      "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
       "requires": {
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
@@ -4038,7 +4046,7 @@
         "rimraf": "2.5.4",
         "semver": "5.3.0",
         "tar": "2.2.1",
-        "tar-pack": "3.1.4"
+        "tar-pack": "3.3.0"
       },
       "dependencies": {
         "rimraf": {
@@ -5386,9 +5394,9 @@
       }
     },
     "tar-pack": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
-      "integrity": "sha1-vIz5oi9YMnOfEvORDaweuXtJcIw=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+      "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
       "requires": {
         "debug": "2.2.0",
         "fstream": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eg": "./bin/index.js"
   },
   "dependencies": {
-    "bcrypt": "1.0.0",
+    "bcrypt": "1.0.2",
     "bluebird": "3.5.0",
     "body-parser": "1.17.2",
     "chalk": "1.1.3",


### PR DESCRIPTION
With this update, `npm install` moves a lot faster, as bcrypt@1.0.2 has pre-build binaries.  There's an added benefit of no `ERR:` messages on install, as well.