### PR TITLE
Fix error in capturing key/cert file path - connects to #367

### DIFF
--- a/lib/gateway/server.js
+++ b/lib/gateway/server.js
@@ -19,10 +19,10 @@ module.exports.bootstrap = function (app) {
 function createTlsServer (httpsConfig, app) {
   let defaultCert = null;
   let sniCerts = [];
-  
+
   let domainCount = httpsConfig.tls.length;
   let domainNames = [];
-	
+
   httpsConfig.tls.forEach(domainObj => {
     domainNames = [...domainNames, Object.getOwnPropertyNames(domainObj)];
   });

--- a/lib/gateway/server.js
+++ b/lib/gateway/server.js
@@ -19,10 +19,17 @@ module.exports.bootstrap = function (app) {
 function createTlsServer (httpsConfig, app) {
   let defaultCert = null;
   let sniCerts = [];
+  
+  let domainCount = httpsConfig.tls.length;
+  let domainNames = [];
+	
+  httpsConfig.tls.forEach(domainObj => {
+    domainNames = [...domainNames, Object.getOwnPropertyNames(domainObj)];
+  });
 
-  for (let el in httpsConfig.tls) {
-    let domain = el;
-    let certPaths = httpsConfig.tls[el];
+  for (let i = 0; i < domainCount; i++) {
+    let domain = domainNames[i].toString();
+    let certPaths = httpsConfig.tls[i][domain];
     let cert;
     if (domain === 'default') {
       cert = defaultCert = {};

--- a/lib/gateway/server.js
+++ b/lib/gateway/server.js
@@ -21,11 +21,9 @@ function createTlsServer (httpsConfig, app) {
   let sniCerts = [];
 
   let domainCount = httpsConfig.tls.length;
-  let domainNames = [];
-
-  httpsConfig.tls.forEach(domainObj => {
-    domainNames = [...domainNames, Object.getOwnPropertyNames(domainObj)];
-  });
+  const domainNames = httpsConfig.tls
+    .map(Object.getOwnPropertyNames)
+    .reduce((a, b) => a.concat(b));
 
   for (let i = 0; i < domainCount; i++) {
     let domain = domainNames[i].toString();


### PR DESCRIPTION
When opening an https connection I noticed that express-gateway/lib/gateway/server.js is having issues properly capturing the file path in the .yml.

The for in loop is trying to pull properties from `httpsConfig.tls` when the object is defined as an array

```javascript
//httpsConfig
{
    "port": 9443,
    "tls": [
        {
            "localhost": {
                "key": "localhost.key.pem",
                "cert": "localhost.cert.pem"
            }
        },
        {
            "default": {
                "key": "localhost.key.pem",
                "cert": "localhost.cert.pem"
            }
        }
    ]
}
``` 

The issue was resolved by looping through the `tls` array and assigning each domain object to `certPaths`.