### PR TITLE
adding alias to make it accept dir name

### DIFF
--- a/bin/generators/gateway/create.js
+++ b/bin/generators/gateway/create.js
@@ -31,7 +31,7 @@ module.exports = class extends eg.Generator {
             choices: ['basic', 'getting-started', undefined]
           })
           .option('d', {
-            alias: 'dir',
+            alias: ['dir', 'directory'],
             describe: 'Directory where the Express Gateway will be installed',
             demandOption: false,
             type: 'string'


### PR DESCRIPTION
eg gateway create -t getting-started -n test -d "/var/folders/mm/kl51qfl11db9fhm3fp01mkt40000gn/T/a4d9a6ac-57b2-4e15-9ac2-f3cce392dfd3"

fails to use provided folder and shows prompt 

-d was ignored because in code it uses `argv.directory` but only `d` and `dir` are registered as aliases