### PR TITLE
fixed example pipeline definitions

### DIFF
--- a/bin/generators/gateway/templates/basic/config/gateway.config.yml
+++ b/bin/generators/gateway/templates/basic/config/gateway.config.yml
@@ -19,7 +19,7 @@ policies:
   - proxy
   - rate-limit
 pipelines:
-  - name: basic
+  basic:
     apiEndpoints:
       - api
     policies:

--- a/bin/generators/gateway/templates/getting-started/config/gateway.config.yml
+++ b/bin/generators/gateway/templates/getting-started/config/gateway.config.yml
@@ -20,7 +20,7 @@ policies:
   - proxy
   - rate-limit
 pipelines:
-  - name: default
+  default:
     apiEndpoints:
       - api
     policies:

--- a/lib/config/gateway.config.yml
+++ b/lib/config/gateway.config.yml
@@ -2,7 +2,7 @@ http:
   port: 8080
 # https:
 #   port: 9999
-#   tls: {} 
+#   tls: {}
 admin: # remove this section to disable admin API
   port: 9876
   hostname: localhost # use 0.0.0.0 to listen on all IPv4 interfaces 
@@ -16,7 +16,7 @@ policies:
   - proxy
   - key-auth
 pipelines:
-  - name: adminAPI
+  adminAPI:
     apiEndpoints:
       - api
     policies:


### PR DESCRIPTION
It doesn't break EG. it will work with any variant 
The difference is in syntax and logs 
info: [EG:gateway] processing pipeline **adminAPI**
vs 
info: [EG:gateway] processing pipeline **0**