### PR TITLE
Fix the appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ cache:
   - node_modules
 install:
   - ps: Install-Product node $env:nodejs_version
-  - if exist node_modules npm prune --ignore=node_modules/\.bin
   - if exist node_modules npm rebuild
   - npm install
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ cache:
   - node_modules
 install:
   - ps: Install-Product node $env:nodejs_version
-  - if exist node_modules npm prune
+  - if exist node_modules npm prune --ignore=node_modules/\.bin
   - if exist node_modules npm rebuild
   - npm install
 build: off


### PR DESCRIPTION
`npm prune` is not a required command - the only one to make sure to do while changing node versions should be `npm rebuild`