### PR TITLE
Adds list credentials modes

### DIFF
--- a/admin/credentials.js
+++ b/admin/credentials.js
@@ -27,10 +27,10 @@ module.exports = function (client) {
         .get(baseUrl + `${type}/${credentialId}`)
         .then(res => res.body);
     },
-    list (consumerId, include) {
+    list (consumerId, filter) {
       if (!consumerId) throw new Error('Consumer Id is required');
       return client
-        .get(`${baseUrl}${consumerId}?include=${include}`)
+        .get(`${baseUrl}${consumerId}?filter=${filter || ''}`)
         .then(res => res.body);
     },
     addScope (credentialId, type, scope) {

--- a/admin/credentials.js
+++ b/admin/credentials.js
@@ -27,10 +27,10 @@ module.exports = function (client) {
         .get(baseUrl + `${type}/${credentialId}`)
         .then(res => res.body);
     },
-    list (consumerId, mode) {
+    list (consumerId, include) {
       if (!consumerId) throw new Error('Consumer Id is required');
       return client
-        .get(`${baseUrl}${consumerId}?mode=${mode}`)
+        .get(`${baseUrl}${consumerId}?include=${include}`)
         .then(res => res.body);
     },
     addScope (credentialId, type, scope) {

--- a/admin/credentials.js
+++ b/admin/credentials.js
@@ -27,10 +27,10 @@ module.exports = function (client) {
         .get(baseUrl + `${type}/${credentialId}`)
         .then(res => res.body);
     },
-    list (consumerId) {
+    list (consumerId, getAll = false) {
       if (!consumerId) throw new Error('Consumer Id is required');
       return client
-        .get(baseUrl + consumerId)
+        .get(`${baseUrl}${consumerId}?getAll=${getAll ? 1 : ''}`)
         .then(res => res.body);
     },
     addScope (credentialId, type, scope) {
@@ -52,7 +52,6 @@ module.exports = function (client) {
         .send({scopes})
         .then(res => res.body);
     }
-
   };
   function validate (credentialId, type) {
     if (!credentialId) throw new Error('Credential Id is required');

--- a/admin/credentials.js
+++ b/admin/credentials.js
@@ -27,10 +27,10 @@ module.exports = function (client) {
         .get(baseUrl + `${type}/${credentialId}`)
         .then(res => res.body);
     },
-    list (consumerId, getAll = false) {
+    list (consumerId, mode) {
       if (!consumerId) throw new Error('Consumer Id is required');
       return client
-        .get(`${baseUrl}${consumerId}?getAll=${getAll ? 1 : ''}`)
+        .get(`${baseUrl}${consumerId}?mode=${mode}`)
         .then(res => res.body);
     },
     addScope (credentialId, type, scope) {

--- a/admin/credentials.js
+++ b/admin/credentials.js
@@ -4,21 +4,21 @@ module.exports = function (client) {
     create (consumerId, type, credential) {
       return client
         .post(baseUrl)
-        .send({credential, consumerId, type})
+        .send({ credential, consumerId, type })
         .then(res => res.body);
     },
     deactivate (credentialId, type) {
       validate(credentialId, type);
       return client
         .put(baseUrl + type + '/' + credentialId + '/status')
-        .send({status: false})
+        .send({ status: false })
         .then(res => res.body);
     },
     activate (credentialId, type) {
       validate(credentialId, type);
       return client
         .put(baseUrl + type + '/' + credentialId + '/status')
-        .send({status: true})
+        .send({ status: true })
         .then(res => res.body);
     },
     info (credentialId, type) {
@@ -29,8 +29,9 @@ module.exports = function (client) {
     },
     list (consumerId, filter) {
       if (!consumerId) throw new Error('Consumer Id is required');
+      const filterUrl = filter ? `?filter=${filter}` : '';
       return client
-        .get(`${baseUrl}${consumerId}?filter=${filter || ''}`)
+        .get(`${baseUrl}${consumerId}${filterUrl}`)
         .then(res => res.body);
     },
     addScope (credentialId, type, scope) {
@@ -49,7 +50,7 @@ module.exports = function (client) {
       validate(credentialId, type);
       return client
         .put(`${baseUrl}${type}/${credentialId}/scopes/`)
-        .send({scopes})
+        .send({ scopes })
         .then(res => res.body);
     }
   };

--- a/admin/credentials.js
+++ b/admin/credentials.js
@@ -7,6 +7,7 @@ module.exports = function (client) {
         .send({ credential, consumerId, type })
         .then(res => res.body);
     },
+
     deactivate (credentialId, type) {
       validate(credentialId, type);
       return client
@@ -14,6 +15,7 @@ module.exports = function (client) {
         .send({ status: false })
         .then(res => res.body);
     },
+
     activate (credentialId, type) {
       validate(credentialId, type);
       return client
@@ -21,31 +23,35 @@ module.exports = function (client) {
         .send({ status: true })
         .then(res => res.body);
     },
+
     info (credentialId, type) {
       validate(credentialId, type);
       return client
         .get(baseUrl + `${type}/${credentialId}`)
         .then(res => res.body);
     },
-    list (consumerId, filter) {
+
+    list (consumerId) {
       if (!consumerId) throw new Error('Consumer Id is required');
-      const filterUrl = filter ? `?filter=${filter}` : '';
       return client
-        .get(`${baseUrl}${consumerId}${filterUrl}`)
+        .get(`${baseUrl}${consumerId}`)
         .then(res => res.body);
     },
+
     addScope (credentialId, type, scope) {
       validate(credentialId, type);
       return client
         .put(`${baseUrl}${type}/${credentialId}/scopes/${scope}`)
         .then(res => res.body);
     },
+
     removeScope (credentialId, type, scope) {
       validate(credentialId, type);
       return client
         .del(`${baseUrl}${type}/${credentialId}/scopes/${scope}`)
         .then(res => res.body);
     },
+
     setScopes (credentialId, type, scopes) {
       validate(credentialId, type);
       return client
@@ -54,6 +60,7 @@ module.exports = function (client) {
         .then(res => res.body);
     }
   };
+
   function validate (credentialId, type) {
     if (!credentialId) throw new Error('Credential Id is required');
     if (!type) throw new Error('Type is required');

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -6,32 +6,24 @@ module.exports = class extends eg.Generator {
 
     this.configureCommand({
       command: 'list [options]',
-      description: 'List all active credentials for Consumer (User or App)',
+      description: 'List Consumer (User or App) credentials',
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
           .example(`$0 ${process.argv[2]} list -c 7498d1a9-7f90-4438-a9b7-0ba4c6022353`)
-          .string(['c'])
-          .boolean(['a', 'd'])
+          .string(['c', 'i'])
           .describe('c', 'Consumer ID: can be User ID or username or app ID')
-          .describe('a', 'List activated and deactivated credentials')
-          .describe('d', 'List only deactivated credentials')
+          .describe('i', 'Comma separated list of credential state (active, archive), default: active')
           .alias('c', 'consumerId').nargs('c', 1)
-          .alias('a', 'all')
-          .alias('d', 'deactivated')
-          .group(['c', 'a'], 'Options:')
+          .alias('i', 'include')
+          .group(['c', 'i'], 'Options:')
     });
   }
 
   prompting () {
-    const {consumerId, all, deactivated} = this.argv;
-    let mode = 'activeOnly';
-    if (all) {
-      mode = 'both';
-    } else if (deactivated) {
-      mode = 'deactivatedOnly';
-    }
-    return this.admin.credentials.list(consumerId, mode)
+    const {consumerId, include} = this.argv;
+
+    return this.admin.credentials.list(consumerId, include)
       .then(data => {
         const credentials = data.credentials;
         if (!credentials || !credentials.length) {

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -26,7 +26,8 @@ module.exports = class extends eg.Generator {
 
     return this.admin.credentials.list(consumerId, filter)
       .then(data => {
-        const credentials = { data };
+        const { credentials } = data;
+
         if (!credentials || !credentials.length) {
           this.log.error(`Consumer ${consumerId} has no credentials`);
           return;

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -16,7 +16,8 @@ module.exports = class extends eg.Generator {
           .describe('f', 'Comma separated list of credential state (active, archived), default: active')
           .alias('c', 'consumerId').nargs('c', 1).required('c')
           .alias('f', 'filter')
-          .group(['c', 'i'], 'Options:')
+          .coerce('f', (val) => val.toLowerCase())
+          .group(['c'], 'Options:')
     });
   }
 

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -6,24 +6,32 @@ module.exports = class extends eg.Generator {
 
     this.configureCommand({
       command: 'list [options]',
-      description: 'List all credentials for Consumer (User or App)',
+      description: 'List all active credentials for Consumer (User or App)',
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
           .example(`$0 ${process.argv[2]} list -c 7498d1a9-7f90-4438-a9b7-0ba4c6022353`)
           .string(['c'])
-          .boolean(['a'])
+          .boolean(['a', 'd'])
           .describe('c', 'Consumer ID: can be User ID or username or app ID')
-          .describe('a', 'List all activated and deactivated credentials')
+          .describe('a', 'List activated and deactivated credentials')
+          .describe('d', 'List only deactivated credentials')
           .alias('c', 'consumerId').nargs('c', 1)
           .alias('a', 'all')
+          .alias('d', 'deactivated')
           .group(['c', 'a'], 'Options:')
     });
   }
 
   prompting () {
-    const {consumerId, all} = this.argv;
-    return this.admin.credentials.list(consumerId, all)
+    const {consumerId, all, deactivated} = this.argv;
+    let mode = 'activeOnly';
+    if (all) {
+      mode = 'both';
+    } else if (deactivated) {
+      mode = 'deactivatedOnly';
+    }
+    return this.admin.credentials.list(consumerId, mode)
       .then(data => {
         const credentials = data.credentials;
         if (!credentials || !credentials.length) {

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -1,5 +1,12 @@
 const eg = require('../../eg');
 
+const filtersTable = {
+  active: (consumer) => consumer.isActive,
+  archived: (consumer) => !filtersTable.active(consumer)
+};
+
+const filterTypes = Object.keys(filtersTable);
+
 module.exports = class extends eg.Generator {
   constructor (args, opts) {
     super(args, opts);
@@ -11,27 +18,38 @@ module.exports = class extends eg.Generator {
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
           .example(`$0 ${process.argv[2]} list -c 7498d1a9-7f90-4438-a9b7-0ba4c6022353`)
-          .string(['c', 'f'])
+          .group(['c', 'f'], 'Options:')
+          .string('c').alias('c', 'consumerId').nargs('c', 1).required('c')
           .describe('c', 'Consumer ID: can be User ID or username or app ID')
+
+          .array('f')
           .describe('f', 'Comma separated list of credential state (active, archived), default: active')
-          .alias('c', 'consumerId').nargs('c', 1).required('c')
           .alias('f', 'filter')
-          .coerce('f', (val) => val.toLowerCase())
-          .group(['c'], 'Options:')
+          .coerce('f', (filters) =>
+            filters.reduce((array, filter) => {
+              if (filterTypes.indexOf(filter) === -1) {
+                throw new Error(`Unrecognised filter type: ${filter}`);
+              }
+              return filtersTable[filter];
+            }, [])
+          )
     });
   }
 
   prompting () {
     const { consumerId, filter } = this.argv;
 
-    return this.admin.credentials.list(consumerId, filter)
+    return this.admin.credentials.list(consumerId)
       .then(data => {
-        const { credentials } = data;
+        let { credentials } = data;
 
         if (!credentials || !credentials.length) {
           this.log.error(`Consumer ${consumerId} has no credentials`);
           return;
         }
+
+        filter.forEach(f => { credentials = credentials.filter(f); });
+
         credentials.forEach(credential => {
           if (this.argv.q) {
             this.stdout(credential.id);

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -25,7 +25,7 @@ module.exports = class extends eg.Generator {
 
     return this.admin.credentials.list(consumerId, filter)
       .then(data => {
-        const credentials = data.credentials;
+        const credentials = { data };
         if (!credentials || !credentials.length) {
           this.log.error(`Consumer ${consumerId} has no credentials`);
           return;
@@ -38,8 +38,6 @@ module.exports = class extends eg.Generator {
           }
         });
       })
-      .catch(err => {
-        this.log.error(err.message);
-      });
+      .catch(err => this.log.error(err.message));
   }
 };

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -11,19 +11,19 @@ module.exports = class extends eg.Generator {
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
           .example(`$0 ${process.argv[2]} list -c 7498d1a9-7f90-4438-a9b7-0ba4c6022353`)
-          .string(['c', 'i'])
+          .string(['c', 'f'])
           .describe('c', 'Consumer ID: can be User ID or username or app ID')
-          .describe('i', 'Comma separated list of credential state (active, archive), default: active')
+          .describe('f', 'Comma separated list of credential state (active, archived), default: active')
           .alias('c', 'consumerId').nargs('c', 1)
-          .alias('i', 'include')
+          .alias('f', 'filter')
           .group(['c', 'i'], 'Options:')
     });
   }
 
   prompting () {
-    const {consumerId, include} = this.argv;
+    const {consumerId, filter} = this.argv;
 
-    return this.admin.credentials.list(consumerId, include)
+    return this.admin.credentials.list(consumerId, filter)
       .then(data => {
         const credentials = data.credentials;
         if (!credentials || !credentials.length) {

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -1,7 +1,7 @@
 const eg = require('../../eg');
 
 module.exports = class extends eg.Generator {
-  constructor(args, opts) {
+  constructor (args, opts) {
     super(args, opts);
 
     this.configureCommand({
@@ -20,7 +20,7 @@ module.exports = class extends eg.Generator {
     });
   }
 
-  prompting() {
+  prompting () {
     const { consumerId, filter } = this.argv;
 
     return this.admin.credentials.list(consumerId, filter)

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -1,7 +1,7 @@
 const eg = require('../../eg');
 
 module.exports = class extends eg.Generator {
-  constructor (args, opts) {
+  constructor(args, opts) {
     super(args, opts);
 
     this.configureCommand({
@@ -14,14 +14,14 @@ module.exports = class extends eg.Generator {
           .string(['c', 'f'])
           .describe('c', 'Consumer ID: can be User ID or username or app ID')
           .describe('f', 'Comma separated list of credential state (active, archived), default: active')
-          .alias('c', 'consumerId').nargs('c', 1)
+          .alias('c', 'consumerId').nargs('c', 1).required('c')
           .alias('f', 'filter')
           .group(['c', 'i'], 'Options:')
     });
   }
 
-  prompting () {
-    const {consumerId, filter} = this.argv;
+  prompting() {
+    const { consumerId, filter } = this.argv;
 
     return this.admin.credentials.list(consumerId, filter)
       .then(data => {

--- a/bin/generators/credentials/list.js
+++ b/bin/generators/credentials/list.js
@@ -12,27 +12,31 @@ module.exports = class extends eg.Generator {
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
           .example(`$0 ${process.argv[2]} list -c 7498d1a9-7f90-4438-a9b7-0ba4c6022353`)
           .string(['c'])
+          .boolean(['a'])
           .describe('c', 'Consumer ID: can be User ID or username or app ID')
+          .describe('a', 'List all activated and deactivated credentials')
           .alias('c', 'consumerId').nargs('c', 1)
-          .group(['c'], 'Options:')
+          .alias('a', 'all')
+          .group(['c', 'a'], 'Options:')
     });
   }
 
   prompting () {
-    return this.admin.credentials.list(this.argv.consumerId)
+    const {consumerId, all} = this.argv;
+    return this.admin.credentials.list(consumerId, all)
       .then(data => {
         const credentials = data.credentials;
         if (!credentials || !credentials.length) {
-          this.log.error(`Consumer ${this.argv.consumerId} has no credentials`);
-        } else {
-          credentials.forEach(app => {
-            if (this.argv.q) {
-              this.stdout(app.id);
-            } else {
-              this.stdout(JSON.stringify(app, null, 2));
-            }
-          });
-        };
+          this.log.error(`Consumer ${consumerId} has no credentials`);
+          return;
+        }
+        credentials.forEach(credential => {
+          if (this.argv.q) {
+            this.stdout(credential.id);
+          } else {
+            this.stdout(JSON.stringify(credential, null, 2));
+          }
+        });
       })
       .catch(err => {
         this.log.error(err.message);

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -83,15 +83,8 @@ module.exports = function () {
   });
 
   router.get('/:consumerId', function (req, res, next) {
-    let filter;
-    try {
-      filter = req.query.filter
-        .split(',');
-    } catch (err) {
-      filter = [];
-    }
     credentialSrv
-      .getCredentials(req.params.consumerId, { filter })
+      .getCredentials(req.params.consumerId)
       .then(credentials => res.json({ credentials }))
       .catch(next);
   });

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -99,9 +99,18 @@ module.exports = function () {
 
   router.get('/:consumerId', function (req, res, next) {
     const {params, query} = req;
+    let include;
+    try {
+      include = query.include
+        .split(',')
+        .map(value => value.trim().toLowerCase())
+        .filter(value => !!value);
+    } catch (err) {
+      include = [];
+    }
     credentialSrv
       .getCredentials(params.consumerId, {
-        mode: query.mode
+        include
       })
       .then(credentials => res.json({credentials}))
       .catch(next);

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -98,13 +98,13 @@ module.exports = function () {
   });
 
   router.get('/:consumerId', function (req, res, next) {
-    credentialSrv.getAllCredentials(req.params.consumerId)
-    .then(credentials => {
-      res.json({credentials});
-    })
-    .catch(err => {
-      next(err);
-    });
+    const {params, query} = req;
+    credentialSrv
+      .getCredentials(params.consumerId, {
+        getAll: !!query.getAll
+      })
+      .then(credentials => res.json({credentials}))
+      .catch(next);
   });
 
   return router;

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -14,19 +14,19 @@ module.exports = function () {
         }
 
         return credentialSrv.insertCredential(req.body.consumerId, req.body.type, req.body.credential)
-         .then(data => {
-           res.json(data);
-         });
+          .then(data => {
+            res.json(data);
+          });
       })
-     .catch(err => {
-       if (!res.headersSent) { // no need to send error if 422 sent
-         next(err);
-       }
-     });
+      .catch(err => {
+        if (!res.headersSent) { // no need to send error if 422 sent
+          next(err);
+        }
+      });
   });
 
   router.put('/:type/:id/status', function (req, res, next) {
-    const {id, type} = req.params;
+    const { id, type } = req.params;
     const status = req.body.status;
 
     credentialSrv.getCredential(id, type)
@@ -35,19 +35,19 @@ module.exports = function () {
           return res.status(404).send('credential not found: ' + id);
         } else {
           if (cred.isActive === status) {
-            return res.json({status: cred.isActive ? 'Active' : 'Inactive'});
+            return res.json({ status: cred.isActive ? 'Active' : 'Inactive' });
           }
         }
         if (status === true) {
           return credentialSrv.activateCredential(id, type)
-          .then(status => {
-            res.json({status: 'Activated'});
-          });
+            .then(status => {
+              res.json({ status: 'Activated' });
+            });
         } else {
           return credentialSrv.deactivateCredential(id, type)
-          .then(status => {
-            res.json({status: 'Deactivated'});
-          });
+            .then(status => {
+              res.json({ status: 'Deactivated' });
+            });
         }
       })
 
@@ -55,53 +55,52 @@ module.exports = function () {
   });
 
   router.put('/:type/:id/scopes/:scope', function (req, res, next) {
-    const {id, type, scope} = req.params;
+    const { id, type, scope } = req.params;
 
     credentialSrv.addScopesToCredential(id, type, scope)
-    .then(success => {
-      res.status(204).send();
-    })
-    .catch(err => {
-      next(err); // TODO: identify cred not found and send 404
-    });
+      .then(success => {
+        res.status(204).send();
+      })
+      .catch(err => {
+        next(err); // TODO: identify cred not found and send 404
+      });
   });
   router.delete('/:type/:id/scopes/:scope', function (req, res, next) {
-    const {id, type, scope} = req.params;
+    const { id, type, scope } = req.params;
     credentialSrv.removeScopesFromCredential(id, type, scope)
-    .then(success => {
-      res.status(204).send();
-    })
-    .catch(err => {
-      next(err); // TODO: identify cred not found and send 404
-    });
+      .then(success => {
+        res.status(204).send();
+      })
+      .catch(err => {
+        next(err); // TODO: identify cred not found and send 404
+      });
   });
   router.put('/:type/:id/scopes', function (req, res, next) {
     // set entire scopes array for cred
-    const {id, type} = req.params;
+    const { id, type } = req.params;
     credentialSrv.setScopesForCredential(id, type, req.body.scopes)
-    .then(success => {
-      res.status(204).send();
-    })
-    .catch(err => {
-      next(err); // TODO: identify cred not found and send 404
-    });
+      .then(success => {
+        res.status(204).send();
+      })
+      .catch(err => {
+        next(err); // TODO: identify cred not found and send 404
+      });
   });
   router.get('/:type/:id', function (req, res, next) {
-    const {id, type} = req.params;
+    const { id, type } = req.params;
     credentialSrv.getCredential(id, type)
-    .then(cred => {
-      res.json(cred);
-    })
-    .catch(err => {
-      next(err); // TODO: identify cred not found and send 404
-    });
+      .then(cred => {
+        res.json(cred);
+      })
+      .catch(err => {
+        next(err); // TODO: identify cred not found and send 404
+      });
   });
 
   router.get('/:consumerId', function (req, res, next) {
-    const {params, query} = req;
     let filter;
     try {
-      filter = query.filter
+      filter = req.query.filter
         .split(',')
         .map(value => value.trim().toLowerCase())
         .filter(value => !!value);
@@ -109,17 +108,15 @@ module.exports = function () {
       filter = [];
     }
     credentialSrv
-      .getCredentials(params.consumerId, {
-        filter
-      })
-      .then(credentials => res.json({credentials}))
+      .getCredentials(req.params.consumerId, { filter })
+      .then(credentials => res.json({ credentials }))
       .catch(next);
   });
 
   return router;
 };
 
-function findConsumer (id) {
+function findConsumer(id) {
   return usersSrv
     .find(id)
     .then(user => {

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -99,18 +99,18 @@ module.exports = function () {
 
   router.get('/:consumerId', function (req, res, next) {
     const {params, query} = req;
-    let include;
+    let filter;
     try {
-      include = query.include
+      filter = query.filter
         .split(',')
         .map(value => value.trim().toLowerCase())
         .filter(value => !!value);
     } catch (err) {
-      include = [];
+      filter = [];
     }
     credentialSrv
       .getCredentials(params.consumerId, {
-        include
+        filter
       })
       .then(credentials => res.json({credentials}))
       .catch(next);

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -86,9 +86,7 @@ module.exports = function () {
     let filter;
     try {
       filter = req.query.filter
-        .split(',')
-        .map(value => value.trim().toLowerCase())
-        .filter(value => !!value);
+        .split(',');
     } catch (err) {
       filter = [];
     }

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -39,15 +39,13 @@ module.exports = function () {
           }
         }
         if (status === true) {
-          return credentialSrv.activateCredential(id, type)
-            .then(status => {
-              res.json({ status: 'Activated' });
-            });
+          return credentialSrv
+            .activateCredential(id, type)
+            .then(status => res.json({ status: 'Activated' }));
         } else {
-          return credentialSrv.deactivateCredential(id, type)
-            .then(status => {
-              res.json({ status: 'Deactivated' });
-            });
+          return credentialSrv
+            .deactivateCredential(id, type)
+            .then(status => res.json({ status: 'Deactivated' }));
         }
       })
 
@@ -57,44 +55,31 @@ module.exports = function () {
   router.put('/:type/:id/scopes/:scope', function (req, res, next) {
     const { id, type, scope } = req.params;
 
-    credentialSrv.addScopesToCredential(id, type, scope)
-      .then(success => {
-        res.status(204).send();
-      })
-      .catch(err => {
-        next(err); // TODO: identify cred not found and send 404
-      });
+    credentialSrv
+      .addScopesToCredential(id, type, scope)
+      .then(success => res.status(204).send())
+      .catch(next);
   });
+
   router.delete('/:type/:id/scopes/:scope', function (req, res, next) {
     const { id, type, scope } = req.params;
     credentialSrv.removeScopesFromCredential(id, type, scope)
-      .then(success => {
-        res.status(204).send();
-      })
-      .catch(err => {
-        next(err); // TODO: identify cred not found and send 404
-      });
+      .then(success => res.status(204).send())
+      .catch(next);
   });
+
   router.put('/:type/:id/scopes', function (req, res, next) {
     // set entire scopes array for cred
     const { id, type } = req.params;
     credentialSrv.setScopesForCredential(id, type, req.body.scopes)
-      .then(success => {
-        res.status(204).send();
-      })
-      .catch(err => {
-        next(err); // TODO: identify cred not found and send 404
-      });
+      .then(success => res.status(204).send())
+      .catch(next);
   });
   router.get('/:type/:id', function (req, res, next) {
     const { id, type } = req.params;
     credentialSrv.getCredential(id, type)
-      .then(cred => {
-        res.json(cred);
-      })
-      .catch(err => {
-        next(err); // TODO: identify cred not found and send 404
-      });
+      .then(cred => res.json(cred))
+      .catch(next);
   });
 
   router.get('/:consumerId', function (req, res, next) {
@@ -116,7 +101,7 @@ module.exports = function () {
   return router;
 };
 
-function findConsumer(id) {
+function findConsumer (id) {
   return usersSrv
     .find(id)
     .then(user => {

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -101,7 +101,7 @@ module.exports = function () {
     const {params, query} = req;
     credentialSrv
       .getCredentials(params.consumerId, {
-        getAll: !!query.getAll
+        mode: query.mode
       })
       .then(credentials => res.json({credentials}))
       .catch(next);

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -144,8 +144,15 @@ s.getCredential = function (id, type, options) {
     });
 };
 
-s.getAllCredentials = function (consumerId) {
-  return credentialDao.getAllCredentials(consumerId);
+s.getCredentials = function (consumerId, options = {}) {
+  return credentialDao
+    .getAllCredentials(consumerId)
+    .then((credentials) => {
+      if (!options.getAll) {
+        credentials = credentials.filter((credential) => credential.isActive);
+      }
+      return credentials;
+    });
 };
 
 s.deactivateCredential = function (id, type) {

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -148,21 +148,19 @@ s.getCredentials = function (consumerId, options = {}) {
   return credentialDao
     .getAllCredentials(consumerId)
     .then((credentials) => {
-      const include = Array.isArray(options.include) ? options.include : [];
-      include.sort();
-      let filter;
-      switch (include.join(',')) {
-        case 'active,archive':
-          filter = null;
-          break;
-        case 'archive':
-          filter = (credential) => !credential.isActive;
-          break;
-        default: // active
-          filter = (credential) => credential.isActive;
-          break;
+      const filter = Array.isArray(options.filter) ? options.filter : [];
+      if (!filter.length) {
+        filter.push('active');
       }
-      return filter ? credentials.filter(filter) : credentials;
+      const showActive = filter.indexOf('active') !== -1;
+      const showArchived = filter.indexOf('archived') !== -1;
+      if (showActive && !showArchived) {
+        return credentials.filter(c => c.isActive);
+      }
+      if (!showActive && showArchived) {
+        return credentials.filter(c => !c.isActive);
+      }
+      return credentials;
     });
 };
 

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -148,16 +148,21 @@ s.getCredentials = function (consumerId, options = {}) {
   return credentialDao
     .getAllCredentials(consumerId)
     .then((credentials) => {
-      switch (options.mode) {
-        case 'deactivatedOnly':
-          credentials = credentials.filter((credential) => !credential.isActive);
+      const include = Array.isArray(options.include) ? options.include : [];
+      include.sort();
+      let filter;
+      switch (include.join(',')) {
+        case 'active,archive':
+          filter = null;
           break;
-        case 'both':
+        case 'archive':
+          filter = (credential) => !credential.isActive;
           break;
-        default: // active only by default
-          credentials = credentials.filter((credential) => credential.isActive);
+        default: // active
+          filter = (credential) => credential.isActive;
+          break;
       }
-      return credentials;
+      return filter ? credentials.filter(filter) : credentials;
     });
 };
 

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -148,8 +148,14 @@ s.getCredentials = function (consumerId, options = {}) {
   return credentialDao
     .getAllCredentials(consumerId)
     .then((credentials) => {
-      if (!options.getAll) {
-        credentials = credentials.filter((credential) => credential.isActive);
+      switch (options.mode) {
+        case 'deactivatedOnly':
+          credentials = credentials.filter((credential) => !credential.isActive);
+          break;
+        case 'both':
+          break;
+        default: // active only by default
+          credentials = credentials.filter((credential) => credential.isActive);
       }
       return credentials;
     });

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -153,13 +153,16 @@ s.getCredentials = function (consumerId, options = {}) {
         filter.push('active');
       }
       const showActive = filter.indexOf('active') !== -1;
-      const showArchived = filter.indexOf('archived') !== -1;
+      const showArchived = filter.indexOf('archive') !== -1;
+
       if (showActive && !showArchived) {
         return credentials.filter(c => c.isActive);
       }
+
       if (!showActive && showArchived) {
         return credentials.filter(c => !c.isActive);
       }
+
       return credentials;
     });
 };

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -144,27 +144,8 @@ s.getCredential = function (id, type, options) {
     });
 };
 
-s.getCredentials = function (consumerId, options = {}) {
-  return credentialDao
-    .getAllCredentials(consumerId)
-    .then((credentials) => {
-      const filter = Array.isArray(options.filter) ? options.filter : [];
-      if (!filter.length) {
-        filter.push('active');
-      }
-      const showActive = filter.indexOf('active') !== -1;
-      const showArchived = filter.indexOf('archive') !== -1;
-
-      if (showActive && !showArchived) {
-        return credentials.filter(c => c.isActive);
-      }
-
-      if (!showActive && showArchived) {
-        return credentials.filter(c => !c.isActive);
-      }
-
-      return credentials;
-    });
+s.getCredentials = function (consumerId) {
+  return credentialDao.getAllCredentials(consumerId);
 };
 
 s.deactivateCredential = function (id, type) {

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -34,7 +34,7 @@ describe('eg credentials list -c ', () => {
   };
 
   const createCredential = (type, options = {}, isActive = true) => {
-    const {credentials} = adminHelper.admin;
+    const { credentials } = adminHelper.admin;
     return credentials
       .create(username, type, options)
       .then((credential) => {
@@ -43,7 +43,7 @@ describe('eg credentials list -c ', () => {
 
         switch (type) {
           case 'key-auth':
-            const {keyId} = credential;
+            const { keyId } = credential;
             createdKeyAuthKeys.add(keyId, isActive);
             if (!isActive) {
               promises.push(credentials.deactivate(keyId, type));
@@ -56,7 +56,7 @@ describe('eg credentials list -c ', () => {
   };
 
   before(() => {
-    ({program, env} = environment.bootstrap());
+    ({ program, env } = environment.bootstrap());
     return adminHelper.start();
   });
 
@@ -80,8 +80,8 @@ describe('eg credentials list -c ', () => {
         username = user.username;
         return Promise.all([
           createCredential('key-auth'),
-          createCredential('basic-auth', {password: 'test1'}),
-          createCredential('oauth2', {secret: 'eg1'}),
+          createCredential('basic-auth', { password: 'test1' }),
+          createCredential('oauth2', { secret: 'eg1' }),
           createCredential('key-auth', {}, false),
           createCredential('key-auth', {}, false),
           createCredential('key-auth', {}, false)
@@ -119,14 +119,9 @@ describe('eg credentials list -c ', () => {
     env.argv = program.parse('credentials list -c ' + username);
   });
 
-<<<<<<< HEAD
-  it('should show credentials', done => {
-    const output = {};
-=======
   it('should show all active and deactivated credentials', done => {
     const types = {};
     const keyAuthKeys = [];
->>>>>>> Adds tests for cli credential list
     env.hijack(namespace, generator => {
       generator.once('run', () => {
         generator.log.error = message => {
@@ -134,14 +129,10 @@ describe('eg credentials list -c ', () => {
         };
         generator.stdout = msg => {
           const crd = JSON.parse(msg);
-<<<<<<< HEAD
-          output[crd.type] = (crd.keyId || crd.secret || crd.password);
-=======
           types[crd.type] = (types[crd.type] || 0) + 1;
           if (crd.type === 'key-auth') {
             keyAuthKeys.push(crd.keyId);
           }
->>>>>>> Adds tests for cli credential list
         };
       });
 

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -198,6 +198,36 @@ describe('eg credentials list -c ', () => {
       });
     });
 
+    env.argv = program.parse('credentials list -i archive -i active -c ' + username);
+  });
+
+  it('should show all active and archive credentials (comma sep list)', done => {
+    const types = {};
+    const keyAuthKeys = [];
+    env.hijack(namespace, generator => {
+      generator.once('run', () => {
+        generator.log.error = message => {
+          done(new Error(message));
+        };
+        generator.stdout = msg => {
+          const crd = JSON.parse(msg);
+          types[crd.type] = (types[crd.type] || 0) + 1;
+          if (crd.type === 'key-auth') {
+            keyAuthKeys.push(crd.keyId);
+          }
+        };
+      });
+
+      generator.once('end', () => {
+        keyAuthKeys.sort();
+        createdKeyAuthKeys.all.sort();
+
+        assert.deepEqual(types, createdTypes.all);
+        assert.deepEqual(keyAuthKeys, createdKeyAuthKeys.all);
+        done();
+      });
+    });
+
     env.argv = program.parse('credentials list -i archive,active -c ' + username);
   });
 });

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -125,7 +125,7 @@ describe('eg credentials list -c ', () => {
     env.argv = program.parse(`credentials list -c ${username}`);
   });
 
-  it('should show all archive credentials', done => {
+  it('should show all archived credentials', done => {
     const types = {};
     const keyAuthKeys = [];
     env.hijack(namespace, generator => {
@@ -152,7 +152,7 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse(`credentials list -f archive -c ${username}`);
+    env.argv = program.parse(`credentials list -f archived -c ${username}`);
   });
 
   it('should show all active and archive credentials', done => {
@@ -182,6 +182,6 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse(`credentials list -f archive,active -c ${username}`);
+    env.argv = program.parse(`credentials list -f archived active -c ${username}`);
   });
 });

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -11,20 +11,14 @@ describe('eg credentials list -c ', () => {
     inc (type, isActive) {
       if (isActive) {
         this.active[type] = (this.active[type] || 0) + 1;
-<<<<<<< HEAD
-=======
       } else {
         this.archive[type] = (this.archive[type] || 0) + 1;
->>>>>>> Rename cli / admin rest filter params
       }
       this.all[type] = (this.all[type] || 0) + 1;
     },
     reset () {
       this.active = {};
-<<<<<<< HEAD
-=======
       this.archive = {};
->>>>>>> Rename cli / admin rest filter params
       this.all = {};
     }
   };
@@ -33,20 +27,14 @@ describe('eg credentials list -c ', () => {
     add (keyId, isActive) {
       if (isActive) {
         this.active.push(keyId);
-<<<<<<< HEAD
-=======
       } else {
         this.archive.push(keyId);
->>>>>>> Rename cli / admin rest filter params
       }
       this.all.push(keyId);
     },
     reset () {
       this.active = [];
-<<<<<<< HEAD
-=======
       this.archive = [];
->>>>>>> Rename cli / admin rest filter params
       this.all = [];
     }
   };
@@ -137,9 +125,6 @@ describe('eg credentials list -c ', () => {
     env.argv = program.parse('credentials list -c ' + username);
   });
 
-<<<<<<< HEAD
-  it('should show all active and deactivated credentials', done => {
-=======
   it('should show all archive credentials', done => {
     const types = {};
     const keyAuthKeys = [];
@@ -171,7 +156,6 @@ describe('eg credentials list -c ', () => {
   });
 
   it('should show all active and archive credentials', done => {
->>>>>>> Rename cli / admin rest filter params
     const types = {};
     const keyAuthKeys = [];
     env.hijack(namespace, generator => {
@@ -198,36 +182,6 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse('credentials list -i archive -i active -c ' + username);
-  });
-
-  it('should show all active and archive credentials (comma sep list, different order)', done => {
-    const types = {};
-    const keyAuthKeys = [];
-    env.hijack(namespace, generator => {
-      generator.once('run', () => {
-        generator.log.error = message => {
-          done(new Error(message));
-        };
-        generator.stdout = msg => {
-          const crd = JSON.parse(msg);
-          types[crd.type] = (types[crd.type] || 0) + 1;
-          if (crd.type === 'key-auth') {
-            keyAuthKeys.push(crd.keyId);
-          }
-        };
-      });
-
-      generator.once('end', () => {
-        keyAuthKeys.sort();
-        createdKeyAuthKeys.all.sort();
-
-        assert.deepEqual(types, createdTypes.all);
-        assert.deepEqual(keyAuthKeys, createdKeyAuthKeys.all);
-        done();
-      });
-    });
-
-    env.argv = program.parse('credentials list -i active,archive -c ' + username);
+    env.argv = program.parse('credentials list -i archive,active -c ' + username);
   });
 });

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -201,7 +201,7 @@ describe('eg credentials list -c ', () => {
     env.argv = program.parse('credentials list -i archive -i active -c ' + username);
   });
 
-  it('should show all active and archive credentials (comma sep list)', done => {
+  it('should show all active and archive credentials (comma sep list, different order)', done => {
     const types = {};
     const keyAuthKeys = [];
     env.hijack(namespace, generator => {
@@ -228,6 +228,6 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse('credentials list -i archive,active -c ' + username);
+    env.argv = program.parse('credentials list -i active,archive -c ' + username);
   });
 });

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -11,11 +11,20 @@ describe('eg credentials list -c ', () => {
     inc (type, isActive) {
       if (isActive) {
         this.active[type] = (this.active[type] || 0) + 1;
+<<<<<<< HEAD
+=======
+      } else {
+        this.archive[type] = (this.archive[type] || 0) + 1;
+>>>>>>> Rename cli / admin rest filter params
       }
       this.all[type] = (this.all[type] || 0) + 1;
     },
     reset () {
       this.active = {};
+<<<<<<< HEAD
+=======
+      this.archive = {};
+>>>>>>> Rename cli / admin rest filter params
       this.all = {};
     }
   };
@@ -24,11 +33,20 @@ describe('eg credentials list -c ', () => {
     add (keyId, isActive) {
       if (isActive) {
         this.active.push(keyId);
+<<<<<<< HEAD
+=======
+      } else {
+        this.archive.push(keyId);
+>>>>>>> Rename cli / admin rest filter params
       }
       this.all.push(keyId);
     },
     reset () {
       this.active = [];
+<<<<<<< HEAD
+=======
+      this.archive = [];
+>>>>>>> Rename cli / admin rest filter params
       this.all = [];
     }
   };
@@ -119,7 +137,41 @@ describe('eg credentials list -c ', () => {
     env.argv = program.parse('credentials list -c ' + username);
   });
 
+<<<<<<< HEAD
   it('should show all active and deactivated credentials', done => {
+=======
+  it('should show all archive credentials', done => {
+    const types = {};
+    const keyAuthKeys = [];
+    env.hijack(namespace, generator => {
+      generator.once('run', () => {
+        generator.log.error = message => {
+          done(new Error(message));
+        };
+        generator.stdout = msg => {
+          const crd = JSON.parse(msg);
+          types[crd.type] = (types[crd.type] || 0) + 1;
+          if (crd.type === 'key-auth') {
+            keyAuthKeys.push(crd.keyId);
+          }
+        };
+      });
+
+      generator.once('end', () => {
+        keyAuthKeys.sort();
+        createdKeyAuthKeys.archive.sort();
+
+        assert.deepEqual(types, createdTypes.archive);
+        assert.deepEqual(keyAuthKeys, createdKeyAuthKeys.archive);
+        done();
+      });
+    });
+
+    env.argv = program.parse('credentials list -i archive -c ' + username);
+  });
+
+  it('should show all active and archive credentials', done => {
+>>>>>>> Rename cli / admin rest filter params
     const types = {};
     const keyAuthKeys = [];
     env.hijack(namespace, generator => {
@@ -146,6 +198,6 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse('credentials list -a -c ' + username);
+    env.argv = program.parse('credentials list -i archive,active -c ' + username);
   });
 });

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -1,39 +1,97 @@
 const assert = require('assert');
+const idGen = require('uuid-base62');
 const adminHelper = require('../../common/admin-helper')();
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:credentials:list';
-const idGen = require('uuid-base62');
 
 describe('eg credentials list -c ', () => {
-  let program, env, user, keyCred1;
+  let program, env, username;
+
+  const createdTypes = {
+    inc (type, isActive) {
+      if (isActive) {
+        this.active[type] = (this.active[type] || 0) + 1;
+      }
+      this.all[type] = (this.all[type] || 0) + 1;
+    },
+    reset () {
+      this.active = {};
+      this.all = {};
+    }
+  };
+
+  const createdKeyAuthKeys = {
+    add (keyId, isActive) {
+      if (isActive) {
+        this.active.push(keyId);
+      }
+      this.all.push(keyId);
+    },
+    reset () {
+      this.active = [];
+      this.all = [];
+    }
+  };
+
+  const createCredential = (type, options = {}, isActive = true) => {
+    const {credentials} = adminHelper.admin;
+    return credentials
+      .create(username, type, options)
+      .then((credential) => {
+        const promises = [];
+        createdTypes.inc(type, isActive);
+
+        switch (type) {
+          case 'key-auth':
+            const {keyId} = credential;
+            createdKeyAuthKeys.add(keyId, isActive);
+            if (!isActive) {
+              promises.push(credentials.deactivate(keyId, type));
+            }
+            break;
+        }
+
+        return Promise.all(promises);
+      });
+  };
+
   before(() => {
-    ({ program, env } = environment.bootstrap());
+    ({program, env} = environment.bootstrap());
     return adminHelper.start();
   });
+
   after(() => adminHelper.stop());
 
   beforeEach(() => {
+    createdTypes.reset();
+    createdKeyAuthKeys.reset();
+
     env.prepareHijack();
-    return adminHelper.admin.users.create({
-      username: idGen.v4(),
-      firstname: 'La',
-      lastname: 'Deeda'
-    })
-    .then(createdUser => {
-      user = createdUser;
-      return Promise.all([
-        adminHelper.admin.credentials.create(user.username, 'key-auth', {}),
-        adminHelper.admin.credentials.create(user.username, 'basic-auth', {password: 'test'}),
-        adminHelper.admin.credentials.create(user.username, 'oauth2', {secret: 'eg'})
-      ]);
-    })
-    .then(([keyCred1Res, keyCred2Res, basicCredRes, oauth2CredRes]) => {
-      keyCred1 = keyCred1Res;
-    });
+
+    return adminHelper
+      .admin
+      .users
+      .create({
+        username: idGen.v4(),
+        firstname: 'La',
+        lastname: 'Deeda'
+      })
+      .then(user => {
+        username = user.username;
+        return Promise.all([
+          createCredential('key-auth'),
+          createCredential('basic-auth', {password: 'test1'}),
+          createCredential('oauth2', {secret: 'eg1'}),
+          createCredential('key-auth', {}, false),
+          createCredential('key-auth', {}, false),
+          createCredential('key-auth', {}, false)
+        ]);
+      });
   });
 
-  it('should show credentials', done => {
-    const output = {};
+  it('should show active credentials', done => {
+    const types = {};
+    const keyAuthKeys = [];
     env.hijack(namespace, generator => {
       generator.once('run', () => {
         generator.log.error = message => {
@@ -41,18 +99,62 @@ describe('eg credentials list -c ', () => {
         };
         generator.stdout = msg => {
           const crd = JSON.parse(msg);
-          output[crd.type] = (crd.keyId || crd.secret || crd.password);
+          types[crd.type] = (types[crd.type] || 0) + 1;
+          if (crd.type === 'key-auth') {
+            keyAuthKeys.push(crd.keyId);
+          }
         };
       });
 
       generator.once('end', () => {
-        assert.ok(output['oauth2']);
-        assert.ok(output['basic-auth']);
-        assert.equal(output['key-auth'], keyCred1.keyId);
+        keyAuthKeys.sort();
+        createdKeyAuthKeys.all.sort();
+
+        assert.deepEqual(types, createdTypes.active);
+        assert.deepEqual(keyAuthKeys, createdKeyAuthKeys.active);
         done();
       });
     });
 
-    env.argv = program.parse('credentials list -c ' + user.username);
+    env.argv = program.parse('credentials list -c ' + username);
+  });
+
+<<<<<<< HEAD
+  it('should show credentials', done => {
+    const output = {};
+=======
+  it('should show all active and deactivated credentials', done => {
+    const types = {};
+    const keyAuthKeys = [];
+>>>>>>> Adds tests for cli credential list
+    env.hijack(namespace, generator => {
+      generator.once('run', () => {
+        generator.log.error = message => {
+          done(new Error(message));
+        };
+        generator.stdout = msg => {
+          const crd = JSON.parse(msg);
+<<<<<<< HEAD
+          output[crd.type] = (crd.keyId || crd.secret || crd.password);
+=======
+          types[crd.type] = (types[crd.type] || 0) + 1;
+          if (crd.type === 'key-auth') {
+            keyAuthKeys.push(crd.keyId);
+          }
+>>>>>>> Adds tests for cli credential list
+        };
+      });
+
+      generator.once('end', () => {
+        keyAuthKeys.sort();
+        createdKeyAuthKeys.all.sort();
+
+        assert.deepEqual(types, createdTypes.all);
+        assert.deepEqual(keyAuthKeys, createdKeyAuthKeys.all);
+        done();
+      });
+    });
+
+    env.argv = program.parse('credentials list -a -c ' + username);
   });
 });

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -122,7 +122,7 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse('credentials list -c ' + username);
+    env.argv = program.parse(`credentials list -c ${username}`);
   });
 
   it('should show all archive credentials', done => {
@@ -152,7 +152,7 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse('credentials list -i archive -c ' + username);
+    env.argv = program.parse(`credentials list -f archive -c ${username}`);
   });
 
   it('should show all active and archive credentials', done => {
@@ -182,6 +182,6 @@ describe('eg credentials list -c ', () => {
       });
     });
 
-    env.argv = program.parse('credentials list -i archive,active -c ' + username);
+    env.argv = program.parse(`credentials list -f archive,active -c ${username}`);
   });
 });


### PR DESCRIPTION
Connected #383

CLI:
```bash
$ eg credentials list [options]
# Options:
# -c --consumerId <consumerId> - Consumer ID: can be User ID or username or app ID
# -f --filter <filter> - Comma separated list of credential state (active, archived), default: active
```

List active credentials for consumer (default):
```bash
$ eg credentials list -c <consumerId>
```
List archived credentials for consumer:
```bash
$ eg credentials list --filter active -c <consumerId>
```
List active and archived credentials for consumer:
```bash
$ eg credentials list -f active,archived -c <consumerId>
# or
$ eg credentials list -f active -f archived -c <consumerId>
```
