### PR TITLE
Dockerfile builds an Alpine-based image with a basic express-gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM node:latest
+FROM node:alpine
+
+ARG VERSION
+ARG TYPE=basic
+
+ENV NODE_ENV production
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
-RUN npm install
-COPY . /usr/src/app
+RUN npm install express-gateway@$VERSION && \
+    ./node_modules/.bin/eg gateway create -n gateway -d . -t $TYPE && \
+    npm cache clean --force
+
 EXPOSE 8080
 
 # HTTPS
@@ -14,5 +20,3 @@ EXPOSE 8080
 # Admin API
 # EXPOSE 9876 
 CMD [ "npm", "run", "start" ]
-
-

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "test-all": "cross-env EG_CONFIG_DIR=test/config EG_DISABLE_CONFIG_WATCH=true mocha --recursive test --timeout 60000",
     "test:unit": "cross-env EG_CONFIG_DIR=test/config EG_DISABLE_CONFIG_WATCH=true mocha --recursive \"./test/{,!(e2e)/**/}*.test.js\" --timeout 5000",
     "test:e2e": "mocha --recursive test/e2e --timeout 60000",
+    "docker": "docker build -t express-gateway:v$npm_package_version --build-arg VERSION=$npm_package_version - < Dockerfile",
+    "docker-gs": "docker build -t express-gateway:v${npm_package_version}-getting-started --build-arg VERSION=$npm_package_version --build-arg TYPE=getting-started - < Dockerfile",
     "mocha-istanbul": "nyc --reporter=lcov npm run test-all && nyc report --report=lcov > coverage.lcov && codecov"
   },
   "bin": {


### PR DESCRIPTION
The Dockerfile takes the version and scaffold type as a build argument, so it can be used to generate other instance types.

Two script targets were also added to `package.json` to automatically create images for `basic` and `getting-started`.