### PR TITLE
fix: remove broken logger.error()

### DIFF
--- a/lib/policies/rate-limit/rate-limit.js
+++ b/lib/policies/rate-limit/rate-limit.js
@@ -1,5 +1,4 @@
 let RateLimit = require('express-rate-limit');
-const logger = require('../../logger').logPolicy;
 
 module.exports = (params) => {
   if (params.rateLimitBy) {
@@ -7,7 +6,7 @@ module.exports = (params) => {
       try {
         return req.egContext.evaluateAsTemplateString(params.rateLimitBy);
       } catch (err) {
-        logger.error('Failed to generate rate-limit key with config: %s; %s', params.rateLimitBy, err.message);
+        console.log('Failed to generate rate-limit key with config: %s; %s', params.rateLimitBy, err.message);
       }
     };
   }


### PR DESCRIPTION
I kept getting this error when my rate limiting policy had a bad `rateLimitBy`, looks like `logger.error()` doesn't actually work

```
^C$ npm start

> rate-limit@1.0.0 start /home/val/Workspace/meanIT/LunchBadger/rate-limit
> node server.js

gateway http server listening on :::8080
admin http server listening on 127.0.0.1:9876
TypeError: Cannot read property 'error' of undefined
    at Object.params.keyGenerator (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express-gateway/lib/policies/rate-limit/rate-limit.js:10:15)
    at rateLimit (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express-rate-limit/lib/express-rate-limit.js:56:27)
    at router.use (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express-gateway/lib/gateway/pipelines.js:171:11)
    at Layer.handle [as handle_request] (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:317:13)
    at /home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:335:12)
    at next (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:275:10)
    at /home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express-gateway/lib/policies/expression/expression.js:5:3
    at router.use (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express-gateway/lib/gateway/pipelines.js:171:11)
    at Layer.handle [as handle_request] (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:317:13)
    at /home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:335:12)
    at next (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express/lib/router/index.js:275:10)
    at passport.authenticate (/home/val/Workspace/meanIT/LunchBadger/rate-limit/node_modules/express-gateway/lib/policies/key-auth/keyauth.js:57:9)
```