### PR TITLE
admin API cors support

### DIFF
--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -2,6 +2,7 @@ let logger = require('../logger').admin;
 const yaml = require('js-yaml');
 const fs = require('fs');
 const path = require('path');
+const cors = require('cors');
 const eventBus = require('../eventBus');
 const swaggerUi = require('swagger-ui-express');
 
@@ -16,7 +17,9 @@ module.exports = function ({plugins, config} = {}) {
   let express = require('express');
   let app = express();
   let bodyParser = require('body-parser');
-
+  if (cfg.admin.cors) {
+    app.use(cors(cfg.admin.cors));
+  }
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
   app.use((req, res, next) => {

--- a/test/rest-api/cors.test.js
+++ b/test/rest-api/cors.test.js
@@ -1,0 +1,45 @@
+let adminHelper = require('../common/admin-helper')();
+let testHelper = require('../common/routing.helper');
+const Config = require('../../lib/config/config');
+
+describe('admin server built-in cors', () => {
+  let config = new Config();
+  let helper = testHelper();
+  before('setup', () => {
+    config.gatewayConfig = {
+      http: { port: 0 },
+      admin: {
+        port: 0,
+        cors: {
+          origin: 'http://www.example.com',
+          methods: 'HEAD,PUT,PATCH,POST,DELETE',
+          allowedHeaders: 'X-TEST'
+        }
+      }
+
+    };
+    return adminHelper.start({config}).then(adminApp => {
+      helper.setupApp(adminApp);
+    });
+  });
+
+  after(() => {
+    return adminHelper.stop();
+  });
+
+  it('should allow first request for host', helper.validateOptions({
+    setup: {
+      url: '/',
+      preflight: true
+    },
+    test: {
+      url: '/',
+      statusCode: 204,
+      headers: {
+        'access-control-allow-origin': 'http://www.example.com',
+        'access-control-allow-methods': 'HEAD,PUT,PATCH,POST,DELETE',
+        'access-control-allow-headers': 'X-TEST'
+      }
+    }
+  }));
+});


### PR DESCRIPTION
@kolbinski requested CORS support for Admin API. Here it is 
Example config 
```
admin: {
        port: 0,
        cors: {
          origin: 'http://www.example.com',
          methods: 'HEAD,PUT,PATCH,POST,DELETE',
          allowedHeaders: 'X-TEST'
        }
      }
```