### PR TITLE
Authenticating consumer no longer requires options to be passed, all…

### DIFF
--- a/lib/services/auth.js
+++ b/lib/services/auth.js
@@ -105,8 +105,7 @@ s.authorizeCredential = function (id, authType, scopes) {
   });
 };
 
-s.validateConsumer = function (id, options) {
-  options = options || {};
+s.validateConsumer = function (id, options = {}) {
   return applications.get(id)
   .then(app => {
     if (app && app.isActive) {

--- a/lib/services/auth.js
+++ b/lib/services/auth.js
@@ -106,6 +106,7 @@ s.authorizeCredential = function (id, authType, scopes) {
 };
 
 s.validateConsumer = function (id, options) {
+  options = options || {}
   return applications.get(id)
   .then(app => {
     if (app && app.isActive) {

--- a/lib/services/auth.js
+++ b/lib/services/auth.js
@@ -106,7 +106,7 @@ s.authorizeCredential = function (id, authType, scopes) {
 };
 
 s.validateConsumer = function (id, options) {
-  options = options || {}
+  options = options || {};
   return applications.get(id)
   .then(app => {
     if (app && app.isActive) {


### PR DESCRIPTION
Previously, authenticateToken() did not work when needing to validate consumer due to not passing options. 

As options are not required, don't make them required.