### PR TITLE
Changes for the upcoming version

### DIFF
--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -49,7 +49,7 @@ function find (type = null, name = null) {
   } else {
     return registeredKeys
       .filter(item => !type || item.type === type)
-      .map(key => ({ key: key.key, type: key.type, schema: ajv.getSchema(key.key).schema }));
+      .map(key => ({ key: key.key, type: key.type, name: key.name, schema: ajv.getSchema(key.key).schema }));
   }
 }
 

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -7,7 +7,11 @@ const ajv = new Ajv({
 
 const buildKey = (type, name) => `${type}:${name}`;
 
-const registeredKeys = [];
+const registeredKeys = predefined.map((predefinedSchema) => ({
+  type: 'core',
+  key: predefinedSchema.$id,
+  name: predefinedSchema.$id
+}));
 
 function register (type, name, schema) {
   const key = buildKey(type, name);
@@ -45,7 +49,7 @@ function find (type = null, name = null) {
   } else {
     return registeredKeys
       .filter(item => !type || item.type === type)
-      .map(key => ({ key: key.type, type: key.name, schema: ajv.getSchema(key.key).schema }));
+      .map(key => ({ key: key.key, type: key.type, schema: ajv.getSchema(key.key).schema }));
   }
 }
 

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -40,7 +40,7 @@ function find (type = null, name = null) {
   if (type && name) {
     const item = ajv.getSchema(buildKey(type, name));
     if (item) {
-      return [{ type, name, schema: item.schema }];
+      return { type, name, schema: item.schema };
     }
   } else {
     return registeredKeys

--- a/test/rest-api/schemas.test.js
+++ b/test/rest-api/schemas.test.js
@@ -45,10 +45,10 @@ describe('REST: schemas', () => {
       return adminHelper.admin.config.schemas
         .list('policy')
         .then((schemas) => {
-          const found = schemas.find(schema => schema.type === 'basic-auth');
-          const other = schemas.filter(schema => schema.key !== 'policy');
-          assert.equal(found.type, 'basic-auth');
-          assert.equal(found.key, 'policy');
+          const found = schemas.find(schema => schema.name === 'basic-auth');
+          const other = schemas.filter(schema => schema.type !== 'policy');
+          assert.equal(found.name, 'basic-auth');
+          assert.equal(found.type, 'policy');
           assert.isDefined(found.schema);
           assert.equal(other.length, 0);
         });
@@ -57,9 +57,8 @@ describe('REST: schemas', () => {
     it('should find basic-auth policy', () => {
       return adminHelper.admin.config.schemas
         .list('policy', 'basic-auth')
-        .then((schemas) => {
-          assert.equal(schemas.length, 1);
-          assert.equal(schemas[0].name, 'basic-auth');
+        .then((schema) => {
+          assert.equal(schema.name, 'basic-auth');
         });
     });
   });


### PR DESCRIPTION
While I was writing the changelog as well the documentation for the upcoming version I noticed two small bugs:

1. When querying the WebAPI for schemas with key and type specified, the result should be a single object and not an array.

2. I found out all predefined schemas aren't being published — now they are.