### PR TITLE
Credential Service — minor refactor

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -47,7 +47,7 @@ to documentation, code, binary files, etc. Even long term committers and TC memb
 pull requests.
 
 A pull request should contain:
-- a spec if applicable, e.g. a GitHub gist, public Google Doc, etc. 
+- a spec if applicable, e.g. a GitHub gist, public Google Doc, etc.
 - tests
 - docs (please open a separate pull request in the express-gateway.io repo and reference the pull request #)
 
@@ -105,7 +105,6 @@ to the TC and the TC uses its standard consensus seeking process to evaluate whe
 not to add this new member. Members who do not participate consistently at the level of
 a majority of the other members are expected to resign.
 
-[comment]: <> (Links Section)
 [express-gateway.io-repo]: https://github.com/ExpressGateway/express-gateway.io
 [circleci]: https://circleci.com/gh/ExpressGateway/express-gateway/tree/master
 [eg-feathub]: http://feathub.com/ExpressGateway/express-gateway

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -1,4 +1,3 @@
-'use strict';
 const credentialDao = require('./credential.dao.js');
 const utils = require('../utils');
 const uuidv4 = require('uuid/v4');
@@ -14,21 +13,16 @@ s.insertScopes = function (scopes) {
         return true; // no scopes to insert
       }
 
-      return credentialDao.insertScopes(newScopes)
-        .then(res => !!res);
-    })
-    .catch((err) => Promise.reject(err)); // TODO: replace with server error
+      return credentialDao.insertScopes(newScopes).then(v => !!v);
+    });
 };
 
 s.removeScopes = function (scopes) {
   const _scopes = validateScopes(scopes);
   if (!_scopes) {
-    return Promise.reject(new Error('invalid scopes')); // TODO: replace with validation error
+    throw new Error('invalid scopes'); // TODO: replace with validation error
   } else {
-    return credentialDao.removeScopes(_scopes)
-      .then(function (removed) {
-        return !!removed;
-      });
+    return credentialDao.removeScopes(_scopes).then(v => !!v);
   }
 };
 
@@ -44,19 +38,19 @@ s.insertCredential = function (id, type, credentialDetails) {
   credentialDetails = credentialDetails || {};
 
   if (!id || typeof id !== 'string' || !type) {
-    return Promise.reject(new Error('invalid credentials')); // TODO: replace with validation error
+    throw new Error('Invalid credentials'); // TODO: replace with validation error
   }
 
   if (!config.models.credentials[type]) {
-    return Promise.reject(new Error('invalid credential type:' + type)); // TODO: replace with validation error
+    throw new Error(`Invalid credential type: ${type}`); // TODO: replace with validation error
   }
 
   return this.getCredential(id, type) // check if credential already exists
     .then((cred) => {
       if (cred) {
         if (cred.isActive) {
-          return Promise.reject(new Error('credential already exists and is active')); // TODO: replace with validation error
-        } else return Promise.reject(new Error('credential already exists but it is inactive. activate credential instead.')); // TODO: replace with validation error
+          throw new Error('credential already exists and is active'); // TODO: replace with validation error
+        } else throw new Error('credential already exists but it is inactive. activate credential instead.'); // TODO: replace with validation error
       }
 
       const credentialConfig = config.models.credentials[type];
@@ -65,7 +59,8 @@ s.insertCredential = function (id, type, credentialDetails) {
       utils.appendUpdatedAt(newCredential);
 
       if (type === 'key-auth') { // TODO: if/else is not a good approach, new way TBD
-        return Promise.all([validateNewCredentialScopes(credentialConfig, credentialDetails),
+        return Promise.all([
+          validateNewCredentialScopes(credentialConfig, credentialDetails),
           validateNewCredentialProperties(credentialConfig, credentialDetails)
         ]).then(([scopes, credentialProps]) => {
           Object.assign(newCredential, credentialProps);
@@ -77,20 +72,21 @@ s.insertCredential = function (id, type, credentialDetails) {
           return Promise.all([
             credentialDao.insertCredential(newCredential.keyId, type, newCredential),
             credentialDao.associateCredentialWithScopes(id, type, scopes)
-          ]).then(() => {
-            if (newCredential.scopes && newCredential.scopes.length > 0) {
-              newCredential.scopes = JSON.parse(newCredential.scopes);
-            }
+          ]);
+        }).then(() => {
+          if (newCredential.scopes && newCredential.scopes.length > 0) {
+            newCredential.scopes = JSON.parse(newCredential.scopes);
+          }
 
-            if (typeof newCredential.isActive === 'string') {
-              newCredential.isActive = newCredential.isActive === 'true';
-            }
-            return newCredential;
-          });
+          if (typeof newCredential.isActive === 'string') {
+            newCredential.isActive = newCredential.isActive === 'true';
+          }
+          return newCredential;
         });
       }
 
-      return Promise.all([validateNewCredentialScopes(credentialConfig, credentialDetails),
+      return Promise.all([
+        validateNewCredentialScopes(credentialConfig, credentialDetails),
         validateAndHashPassword(credentialConfig, credentialDetails),
         validateNewCredentialProperties(credentialConfig, credentialDetails)
       ])
@@ -102,32 +98,34 @@ s.insertCredential = function (id, type, credentialDetails) {
           Object.assign(newCredential, credentialProps);
 
           return Promise.all([
+            password,
             credentialDao.insertCredential(id, type, newCredential),
             credentialDao.associateCredentialWithScopes(id, type, scopes)
-          ])
-            .then(() => {
-              const credential = newCredential;
-              delete credential[credentialConfig.passwordKey];
-              credential.id = id;
-              if (password) {
-                credential[credentialConfig.passwordKey] = password;
-              }
-              if (credential.scopes && credential.scopes.length > 0) {
-                credential.scopes = JSON.parse(credential.scopes);
-              }
-              if (typeof credential.isActive === 'string') {
-                credential.isActive = credential.isActive === 'true';
-              }
-              return credential;
-            })
-            .catch((err) => Promise.reject(new Error('failed to insert credential: ' + err.message))); // TODO: replace with server error
+          ]);
+        }).then(([password]) => {
+          const credential = newCredential;
+          delete credential[credentialConfig.passwordKey];
+          credential.id = id;
+
+          if (password) {
+            credential[credentialConfig.passwordKey] = password;
+          }
+
+          if (credential.scopes && credential.scopes.length > 0) {
+            credential.scopes = JSON.parse(credential.scopes);
+          }
+
+          if (typeof credential.isActive === 'string') {
+            credential.isActive = credential.isActive === 'true';
+          }
+          return credential;
         });
     });
 };
 
 s.getCredential = function (id, type, options) {
   if (!id || !type || typeof id !== 'string' || typeof type !== 'string') {
-    return Promise.reject(new Error('invalid credential')); // TODO: replace with validation error
+    throw new Error('invalid credential'); // TODO: replace with validation error
   }
   return credentialDao.getCredential(id, type)
     .then(credential => {
@@ -150,29 +148,27 @@ s.getCredentials = function (consumerId) {
 
 s.deactivateCredential = function (id, type) {
   if (!id || !type) {
-    return Promise.reject(new Error('invalid credential')); // TODO: replace with validation error
+    throw new Error('invalid credential'); // TODO: replace with validation error
   }
 
   return this.getCredential(id, type) // verify credential exists
     .then((credential) => {
       if (credential) {
-        return credentialDao.deactivateCredential(id, type)
-          .then(() => true);
-      } else return Promise.reject(new Error('credential does not exist')); // TODO: replace with validation error
+        return credentialDao.deactivateCredential(id, type).then(() => true);
+      } else throw new Error('credential does not exist'); // TODO: replace with validation error
     });
 };
 
 s.activateCredential = function (id, type) {
   if (!id || !type) {
-    return Promise.reject(new Error('invalid credential')); // TODO: replace with validation error
+    throw new Error('invalid credential'); // TODO: replace with validation error
   }
 
   return this.getCredential(id, type) // verify credential exists
     .then((credential) => {
       if (credential) {
-        return credentialDao.activateCredential(id, type)
-          .then(() => true);
-      } else return Promise.reject(new Error('credential does not exist')); // TODO: replace with validation error
+        return credentialDao.activateCredential(id, type).then(() => true);
+      } else throw new Error('credential does not exist'); // TODO: replace with validation error
     });
 };
 
@@ -180,7 +176,7 @@ s.updateCredential = function (id, type, properties) {
   return this.getCredential(id, type)
     .then((credential) => {
       if (!credential) {
-        return Promise.reject(new Error('credential does not exist')); // TODO: replace with validation error
+        throw new Error('credential does not exist'); // TODO: replace with validation error
       }
       return validateUpdatedCredentialProperties(type, properties);
     })
@@ -195,83 +191,78 @@ s.updateCredential = function (id, type, properties) {
 
 s.removeCredential = function (id, type) {
   if (!id || !type) {
-    return Promise.reject(new Error('invalid credential')); // TODO: replace with validation error
+    throw new Error('invalid credential'); // TODO: replace with validation error
   }
 
-  return credentialDao.removeCredential(id, type)
-    .then(() => true);
+  return credentialDao.removeCredential(id, type);
 };
 
 s.removeAllCredentials = function (id) {
   if (!id) {
-    return Promise.reject(new Error('invalid credential')); // TODO: replace with validation error
+    throw new Error('invalid credential'); // TODO: replace with validation error
   }
-  return credentialDao.removeAllCredentials(id)
-    .then(() => true);
+  return credentialDao.removeAllCredentials(id);
 };
 
 s.addScopesToCredential = function (id, type, scopes) {
-  return Promise.all([validateExistingScopes(scopes), this.getCredential(id, type)])
-    .then(([_scopes, credential]) => {
-      if (!credential) {
-        return Promise.reject(new Error('credential not found'));
-      }
+  return Promise.all([
+    validateExistingScopes(scopes),
+    this.getCredential(id, type)
+  ]).then(([_scopes, credential]) => {
+    if (!credential) {
+      throw new Error('credential not found');
+    }
 
-      const existingScopes = credential.scopes ? (Array.isArray(credential.scopes) ? credential.scopes : [credential.scopes]) : [];
-      // Set has unique items
-      const newScopes = [...new Set(_scopes.concat(existingScopes))];
-      return Promise.all([credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
-        credentialDao.associateCredentialWithScopes(id, type, _scopes)
-      ]);
-    })
-    .then(() => true);
+    const existingScopes = credential.scopes ? (Array.isArray(credential.scopes) ? credential.scopes : [credential.scopes]) : [];
+    // Set has unique items
+    const newScopes = [...new Set(_scopes.concat(existingScopes))];
+    return Promise.all([
+      credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
+      credentialDao.associateCredentialWithScopes(id, type, _scopes)
+    ]).then(() => true);
+  });
 };
 
 s.removeScopesFromCredential = function (id, type, scopes) {
   return Promise.all([validateScopes(scopes), this.getCredential(id, type)])
     .then(([_scopes, credential]) => {
       if (!credential) {
-        return Promise.reject(new Error('credential not found'));
+        throw new Error('credential not found');
       }
 
       const existingScopes = credential.scopes ? (Array.isArray(credential.scopes) ? credential.scopes : [credential.scopes]) : [];
       const newScopes = existingScopes.filter(val => _scopes.indexOf(val) === -1);
-      return Promise.all([credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
+      return Promise.all([
+        credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
         credentialDao.dissociateCredentialFromScopes(id, type, _scopes)
-      ]);
-    })
-    .then(() => true);
+      ]).then(() => true);
+    });
 };
 
 s.setScopesForCredential = function (id, type, scopes) {
   return Promise.all([validateScopes(scopes), this.getCredential(id, type)])
     .then(([_scopes, credential]) => {
       if (!credential) {
-        return Promise.reject(new Error('credential not found'));
+        throw new Error('credential not found');
       }
 
       return credentialDao.updateCredential(id, type, { scopes: JSON.stringify(_scopes) });
-    })
-    .then(() => true);
+    }).then(() => true);
 };
 
 function validateAndHashPassword (credentialConfig, credentialDetails) {
   if (credentialDetails[credentialConfig.passwordKey]) {
     return utils.saltAndHash(credentialDetails[credentialConfig.passwordKey])
-      .then(hash => {
-        return { hash };
-      });
+      .then(hash => ({ hash }));
   }
 
   if (!credentialConfig.autoGeneratePassword) {
-    return Promise.reject(new Error(`${credentialConfig.passwordKey} is required`)); // TODO: replace with validation error
+    throw new Error(`${credentialConfig.passwordKey} is required`); // TODO: replace with validation error
   }
   const password = uuidv4();
 
   return utils.saltAndHash(password)
-    .then((hash) => {
-      return { hash, password };
-    });
+    .then((hash) => ({ hash, password }));
 }
 
 function validateNewCredentialScopes (credentialConfig, credentialDetails) {
@@ -284,7 +275,7 @@ function validateNewCredentialScopes (credentialConfig, credentialDetails) {
   }
 
   if (credentialConfig.properties['scopes'].isRequired) {
-    return Promise.reject(new Error('scopes are required')); // TODO: replace with validation error
+    throw new Error('scopes are required'); // TODO: replace with validation error
   }
 
   if (credentialConfig.properties['scopes'].defaultValue) {
@@ -304,7 +295,7 @@ function validateNewCredentialProperties (credentialConfig, credentialDetails) {
     const descriptor = credentialConfig.properties[prop];
     if (!credentialDetails[prop]) {
       if (descriptor.isRequired) {
-        return Promise.reject(new Error(`${prop} is required`));
+        throw new Error(`${prop} is required`);
       }
       if (descriptor.defaultValue) {
         newCredentialProperties[prop] = descriptor.defaultValue;
@@ -326,11 +317,11 @@ function validateUpdatedCredentialProperties (type, credentialDetails) {
     }
     if (credentialDetails[prop]) {
       if (typeof credentialDetails[prop] !== 'string') {
-        return Promise.reject(new Error('credential property must be a string')); // TODO: replace with validation error
+        throw new Error('credential property must be a string'); // TODO: replace with validation error
       }
       if (credentialConfig.properties[prop].isMutable !== false) {
         newCredentialProperties[prop] = credentialDetails[prop];
-      } else return Promise.reject(new Error(`${prop} is immutable`));
+      } else throw new Error(`${prop} is immutable`);
     }
   }
 
@@ -338,21 +329,19 @@ function validateUpdatedCredentialProperties (type, credentialDetails) {
 }
 
 function validateNewScopes (scopes) {
-  const _scopes = validateScopes(scopes);
-  return !_scopes ? Promise.reject(new Error('invalid scopes')) // TODO: replace with validation error
-    : Promise.all(_scopes.map(val => s.existsScope(val)))
-      .then(res => {
-        return res.every(val => !val) ? _scopes
-          : Promise.reject(new Error('one or more scopes already exist')); // TODO: replace with validation error
-      });
+  return grabScopesAndExecute(scopes, val => !val);
 }
 
 function validateExistingScopes (scopes) {
+  return grabScopesAndExecute(scopes, val => val);
+}
+
+function grabScopesAndExecute (scopes, fn) {
   const _scopes = validateScopes(scopes);
   return !_scopes ? Promise.reject(new Error('invalid scopes')) // TODO: replace with validation error
-    : Promise.all(_scopes.map(val => s.existsScope(val)))
+    : Promise.all(_scopes.map(s.existsScope))
       .then(res => {
-        return res.every(val => val) ? _scopes
+        return res.every(fn) ? _scopes
           : Promise.reject(new Error('one or more scopes don\'t exist')); // TODO: replace with validation error
       });
 }

--- a/test/services/auth.test.js
+++ b/test/services/auth.test.js
@@ -28,44 +28,44 @@ describe('Auth tests', function () {
 
     originalUserModelConfig = userModelConfig.properties;
     userModelConfig.properties = {
-      firstname: {isRequired: true, isMutable: true},
-      lastname: {isRequired: true, isMutable: true},
-      email: {isRequired: false, isMutable: true}
+      firstname: { isRequired: true, isMutable: true },
+      lastname: { isRequired: true, isMutable: true },
+      email: { isRequired: false, isMutable: true }
     };
 
     db.flushdbAsync()
-    .then(function (didSucceed) {
-      user = {
-        username: 'irfanbaqui',
-        firstname: 'irfan',
-        lastname: 'baqui',
-        email: 'irfan@eg.com'
-      };
+      .then(function (didSucceed) {
+        user = {
+          username: 'irfanbaqui',
+          firstname: 'irfan',
+          lastname: 'baqui',
+          email: 'irfan@eg.com'
+        };
 
-      _credential = {
-        secret: 'password',
-        scopes: [ 'someScope1', 'someScope2', 'someScope3' ]
-      };
+        _credential = {
+          secret: 'password',
+          scopes: ['someScope1', 'someScope2', 'someScope3']
+        };
 
-      userService
-      .insert(user)
-      .then(_user => {
-        should.exist(_user);
-        userFromDb = _user;
-        return credentialService.insertScopes([ 'someScope1', 'someScope2', 'someScope3' ]);
+        userService
+          .insert(user)
+          .then(_user => {
+            should.exist(_user);
+            userFromDb = _user;
+            return credentialService.insertScopes(['someScope1', 'someScope2', 'someScope3']);
+          })
+          .then(() => {
+            return credentialService.insertCredential(user.username, 'oauth2', _credential)
+              .then(function (res) {
+                should.exist(res);
+                done();
+              });
+          });
       })
-      .then(() => {
-        return credentialService.insertCredential(user.username, 'oauth2', _credential)
-        .then(function (res) {
-          should.exist(res);
-          done();
-        });
+      .catch(function (err) {
+        should.not.exist(err);
+        done();
       });
-    })
-    .catch(function (err) {
-      should.not.exist(err);
-      done();
-    });
   });
 
   after(function (done) {
@@ -77,102 +77,102 @@ describe('Auth tests', function () {
   describe('Credential Auth', function () {
     it('should authenticate user', function (done) {
       authService.authenticateCredential(user.username, _credential.secret, 'oauth2')
-      .then(authResponse => {
-        const expectedResponse = Object.assign({
-          type: 'user',
-          id: userFromDb.id,
-          username: user.username,
-          isActive: true
-        }, userFromDb);
-        should.exist(authResponse);
-        should.deepEqual(authResponse, expectedResponse);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
-    });
-
-    it('should not authenticate invalid user with credentials', function (done) {
-      authService.authenticateCredential('invalidUsername', _credential.secret, 'oauth2')
-      .then(authResponse => {
-        should.exist(authResponse);
-        authResponse.should.eql(false);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
-    });
-
-    it('should not authenticate valid user with invalid credentials', function (done) {
-      authService.authenticateCredential(user.username, 'invalidSecret', 'oauth2')
-      .then(authResponse => {
-        should.exist(authResponse);
-        authResponse.should.eql(false);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
-    });
-
-    it('should authorize Credential with scopes', function (done) {
-      authService.authorizeCredential(user.username, 'oauth2', [ 'someScope1', 'someScope2' ])
-      .then((authResponse) => {
-        should.exist(authResponse);
-        authResponse.should.eql(true);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
-    });
-
-    it('should not authorize Credential with invalid scopes', function (done) {
-      authService.authorizeCredential(user.username, 'oauth2', [ 'otherScope', 'someScope2' ])
-      .then((authResponse) => {
-        should.exist(authResponse);
-        authResponse.should.eql(false);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
-    });
-
-    it('should not authorize Credential that is inActive', function (done) {
-      credentialService
-      .deactivateCredential(user.username, 'oauth2')
-      .then(function (res) {
-        should.exist(res);
-        res.should.eql(true);
-      })
-      .then(() => {
-        authService.authorizeCredential(user.username, 'oauth2', [ 'otherScope', 'someScope2' ])
-        .then((authResponse) => {
+        .then(authResponse => {
+          const expectedResponse = Object.assign({
+            type: 'user',
+            id: userFromDb.id,
+            username: user.username,
+            isActive: true
+          }, userFromDb);
           should.exist(authResponse);
-          authResponse.should.eql(false);
-
-          // reset credential back to active status
-          credentialService
-          .activateCredential(user.username, 'oauth2')
-          .then(function (res) {
-            should.exist(res);
-            res.should.eql(true);
-            done();
-          });
+          should.deepEqual(authResponse, expectedResponse);
+          done();
         })
         .catch(function (err) {
           should.not.exist(err);
           done();
         });
-      });
+    });
+
+    it('should not authenticate invalid user with credentials', function (done) {
+      authService.authenticateCredential('invalidUsername', _credential.secret, 'oauth2')
+        .then(authResponse => {
+          should.exist(authResponse);
+          authResponse.should.eql(false);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('should not authenticate valid user with invalid credentials', function (done) {
+      authService.authenticateCredential(user.username, 'invalidSecret', 'oauth2')
+        .then(authResponse => {
+          should.exist(authResponse);
+          authResponse.should.eql(false);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('should authorize Credential with scopes', function (done) {
+      authService.authorizeCredential(user.username, 'oauth2', ['someScope1', 'someScope2'])
+        .then((authResponse) => {
+          should.exist(authResponse);
+          authResponse.should.eql(true);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('should not authorize Credential with invalid scopes', function (done) {
+      authService.authorizeCredential(user.username, 'oauth2', ['otherScope', 'someScope2'])
+        .then((authResponse) => {
+          should.exist(authResponse);
+          authResponse.should.eql(false);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('should not authorize Credential that is inActive', function (done) {
+      credentialService
+        .deactivateCredential(user.username, 'oauth2')
+        .then(function (res) {
+          should.exist(res);
+          res.should.eql(true);
+        })
+        .then(() => {
+          authService.authorizeCredential(user.username, 'oauth2', ['otherScope', 'someScope2'])
+            .then((authResponse) => {
+              should.exist(authResponse);
+              authResponse.should.eql(false);
+
+              // reset credential back to active status
+              credentialService
+                .activateCredential(user.username, 'oauth2')
+                .then(function (res) {
+                  should.exist(res);
+                  res.should.eql(true);
+                  done();
+                });
+            })
+            .catch(function (err) {
+              should.not.exist(err);
+              done();
+            });
+        });
     });
   });
 
@@ -182,97 +182,97 @@ describe('Auth tests', function () {
       const tokenObj = {
         consumerId: userFromDb.id,
         authType: 'oauth2',
-        scopes: [ 'someScope1', 'someScope2', 'someScope3' ]
+        scopes: ['someScope1', 'someScope2', 'someScope3']
       };
 
       tokenService.save(tokenObj)
-      .then((token) => {
-        should.exist(token.access_token);
-        userAccessToken = token.access_token;
-        [tokenId, tokenDecrypted] = token.access_token.split('|');
-        done();
-      });
+        .then((token) => {
+          should.exist(token.access_token);
+          userAccessToken = token.access_token;
+          [tokenId, tokenDecrypted] = token.access_token.split('|');
+          done();
+        });
     });
 
     it('should authenticate token', function (done) {
       authService.authenticateToken(userAccessToken, 'oauth2')
-      .then(authResponse => {
-        const expectedTokenProps = [ 'consumerId', 'expiresAt', 'id', 'scopes', 'createdAt', 'authType', 'tokenDecrypted' ];
-        const expectedConsumerProps = [ 'type', 'createdAt', 'email', 'firstname', 'id', 'isActive', 'lastname', 'updatedAt', 'username' ];
+        .then(authResponse => {
+          const expectedTokenProps = ['consumerId', 'expiresAt', 'id', 'scopes', 'createdAt', 'authType', 'tokenDecrypted'];
+          const expectedConsumerProps = ['type', 'createdAt', 'email', 'firstname', 'id', 'isActive', 'lastname', 'updatedAt', 'username'];
 
-        const expectedResponse = {
-          token: {
-            consumerId: userFromDb.id,
-            authType: 'oauth2',
-            tokenDecrypted: tokenDecrypted,
-            id: tokenId,
-            scopes: [ 'someScope1', 'someScope2', 'someScope3' ]
-          },
-          consumer: {
-            id: userFromDb.id,
-            type: 'user',
-            email: 'irfan@eg.com',
-            firstname: 'irfan',
-            isActive: true,
-            lastname: 'baqui',
-            username: 'irfanbaqui'
-          }
-        };
+          const expectedResponse = {
+            token: {
+              consumerId: userFromDb.id,
+              authType: 'oauth2',
+              tokenDecrypted: tokenDecrypted,
+              id: tokenId,
+              scopes: ['someScope1', 'someScope2', 'someScope3']
+            },
+            consumer: {
+              id: userFromDb.id,
+              type: 'user',
+              email: 'irfan@eg.com',
+              firstname: 'irfan',
+              isActive: true,
+              lastname: 'baqui',
+              username: 'irfanbaqui'
+            }
+          };
 
-        should.exist(authResponse);
-        Object.keys(authResponse.token).sort().should.eql(expectedTokenProps.sort());
-        Object.keys(authResponse.consumer).sort().should.eql(expectedConsumerProps.sort());
-        delete authResponse.token.expiresAt;
-        delete authResponse.token.createdAt;
-        delete authResponse.consumer.createdAt;
-        delete authResponse.consumer.updatedAt;
-        should.deepEqual(authResponse.token, expectedResponse.token);
-        should.deepEqual(authResponse.consumer, expectedResponse.consumer);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+          should.exist(authResponse);
+          Object.keys(authResponse.token).sort().should.eql(expectedTokenProps.sort());
+          Object.keys(authResponse.consumer).sort().should.eql(expectedConsumerProps.sort());
+          delete authResponse.token.expiresAt;
+          delete authResponse.token.createdAt;
+          delete authResponse.consumer.createdAt;
+          delete authResponse.consumer.updatedAt;
+          should.deepEqual(authResponse.token, expectedResponse.token);
+          should.deepEqual(authResponse.consumer, expectedResponse.consumer);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     it('should not authenticate invalid token', function (done) {
       authService.authenticateToken('invalidToken', 'oauth2')
-      .then(authResponse => {
-        should.exist(authResponse);
-        authResponse.should.eql(false);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+        .then(authResponse => {
+          should.exist(authResponse);
+          authResponse.should.eql(false);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     it('should authorize Token', function (done) {
-      authService.authorizeToken(userAccessToken, 'oauth2', [ 'someScope1', 'someScope2' ])
-      .then((authResponse) => {
-        should.exist(authResponse);
-        authResponse.should.eql(true);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+      authService.authorizeToken(userAccessToken, 'oauth2', ['someScope1', 'someScope2'])
+        .then((authResponse) => {
+          should.exist(authResponse);
+          authResponse.should.eql(true);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     it('should not authorize Token with invalid scopes', function (done) {
-      authService.authorizeToken(userAccessToken, 'oauth2', [ 'otherScope', 'someScope2' ])
-      .then((authResponse) => {
-        should.exist(authResponse);
-        authResponse.should.eql(false);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+      authService.authorizeToken(userAccessToken, 'oauth2', ['otherScope', 'someScope2'])
+        .then((authResponse) => {
+          should.exist(authResponse);
+          authResponse.should.eql(false);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
   });
 });

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -14,7 +14,7 @@ describe('Credential service tests', function () {
     const originalModelConfig = config.models.credentials;
     const username = 'someUser';
 
-    before(function (done) {
+    before(() => {
       config.models.credentials.oauth2 = {
         passwordKey: 'secret',
         autoGeneratePassword: true,
@@ -31,146 +31,102 @@ describe('Credential service tests', function () {
         }
       };
 
-      db.flushdbAsync()
-        .then(function (didSucceed) {
-          if (!didSucceed) {
-            console.log('Failed to flush the database');
-          }
-          done();
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
-        });
+      return db.flushdbAsync();
     });
 
-    after(function (done) {
+    after(() => {
       config.models.credentials = originalModelConfig;
-      done();
     });
 
-    it('should insert a credential', function (done) {
+    it('should insert a credential', () => {
       const _credential = {
         secret: 'password'
       };
 
-      credentialService
+      return credentialService
         .insertCredential(username, 'oauth2', _credential)
         .then(function (newCredential) {
           should.exist(newCredential);
           credential = Object.assign(newCredential, _credential);
-          done();
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
         });
     });
 
-    it('should not insert a credential that already exists', function (done) {
+    it('should not insert a credential that already exists', () => {
       const _credential = {
         secret: 'password'
       };
 
-      credentialService
-        .insertCredential(username, 'oauth2', _credential)
-        .then(function (newCredential) {
-          should.not.exist(newCredential);
-          done();
-        })
-        .catch(function (err) {
-          should.exist(err);
-          done();
-        });
+      return should(credentialService.insertCredential(username, 'oauth2', _credential))
+        .be.rejected();
     });
 
-    it('should insert a credential without password specified if autoGeneratePassword is set to true', function (done) {
+    it('should insert a credential without password specified if autoGeneratePassword is set to true', () => {
       const _credential = {};
 
-      credentialService
+      return credentialService
         .insertCredential('someUsername', 'oauth2', _credential)
         .then(function (newCredential) {
           should.exist(newCredential);
           should.exist(newCredential.secret);
           newCredential.secret.length.should.greaterThanOrEqual(10);
-          done();
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
         });
     });
 
-    it('should insert a credential with id but different type that already exists', function (done) {
+    it('should insert a credential with id but different type that already exists', () => {
       const _credential = {
         password: 'password'
       };
 
-      credentialService
+      return credentialService
         .insertCredential(username, 'basic-auth', _credential)
         .then(function (newCredential) {
           should.exist(newCredential);
           newCredential.isActive.should.eql(true);
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should get a credential', function (done) {
-      credentialService
+    it('should get a credential', () => {
+      return credentialService
         .getCredential(username, 'oauth2')
         .then(function (cred) {
           should.exist(cred);
           should.not.exist(cred.secret);
           credential.isActive.should.eql(true);
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should deactivate a credential', function (done) {
-      credentialService
+    it('should deactivate a credential', () => {
+      return credentialService
         .deactivateCredential(username, 'oauth2')
-        .then(function (res) {
-          credentialService
-            .getCredential(username, 'oauth2')
-            .then(function (cred) {
-              should.exist(cred);
-              should.not.exist(cred.secret);
-              cred.isActive.should.eql(false);
-              done();
-            });
-        })
-        .catch(done);
+        .then(() => credentialService.getCredential(username, 'oauth2'))
+        .then((cred) => {
+          should.exist(cred);
+          should.not.exist(cred.secret);
+          cred.isActive.should.eql(false);
+        });
     });
 
-    it('should reactivate a credential', function (done) {
-      credentialService
+    it('should reactivate a credential', () => {
+      return credentialService
         .activateCredential(username, 'oauth2')
         .then(function (res) {
           should.exist(res);
 
-          credentialService
-            .getCredential(username, 'oauth2')
-            .then(function (cred) {
-              should.exist(cred);
-              should.not.exist(cred.secret);
-              cred.isActive.should.eql(true);
-              done();
-            });
+          return credentialService.getCredential(username, 'oauth2');
         })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
+        .then(function (cred) {
+          should.exist(cred);
+          should.not.exist(cred.secret);
+          cred.isActive.should.eql(true);
         });
     });
   });
 
-  describe('Credential Cascade Delete tests', function () {
+  describe('Credential Cascade Delete tests', () => {
     let user;
     const originalModelConfig = config.models.credentials;
 
-    before(function (done) {
+    before(() => {
       config.models.credentials.oauth2 = {
         passwordKey: 'secret',
         autoGeneratePassword: true,
@@ -194,73 +150,56 @@ describe('Credential service tests', function () {
         email: 'irfan@eg.com'
       };
 
-      db.flushdbAsync()
-        .then(function (didSucceed) {
-          if (!didSucceed) {
-            console.log('Failed to flush the database');
-          }
-          userService
-            .insert(user)
-            .then(function (newUser) {
-              should.exist(newUser);
-              user = newUser;
-              credentialService.insertCredential(user.username, 'oauth2')
-                .then((oauthCred) => {
-                  should.exist(oauthCred.secret);
-                  credentialService.insertCredential(user.username, 'basic-auth')
-                    .then((basicAuthCred) => {
-                      should.exist(basicAuthCred.password);
-                      done();
-                    });
-                });
-            });
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
+      return db.flushdbAsync()
+        .then(() => userService.insert(user))
+        .then((newUser) => {
+          user = newUser;
+          return Promise.all([
+            credentialService.insertCredential(user.username, 'oauth2'),
+            credentialService.insertCredential(user.username, 'basic-auth')
+          ]);
         });
     });
 
-    after(function (done) {
+    after(() => {
       config.models.credentials = originalModelConfig;
-      done();
     });
 
-    it('should delete all credentials associated with a user when user is deleted', function (done) {
-      Promise.all([credentialService.getCredential(user.username, 'oauth2'),
-        credentialService.getCredential(user.username, 'basic-auth')])
+    it('should delete all credentials associated with a user when user is deleted', () => {
+      return Promise.all([
+        credentialService.getCredential(user.username, 'oauth2'),
+        credentialService.getCredential(user.username, 'basic-auth')
+      ])
         .then(([oauthRes, basicAuthRes]) => {
           should.exist(oauthRes); // Check to confirm the credentials exist
           should.exist(basicAuthRes);
-          return userService.remove(user.id)
-            .then(res => {
-              should.exist(res);
-              return Promise.all([credentialService.getCredential(user.username, 'oauth2'),
-                credentialService.getCredential(user.username, 'basic-auth')])
-                .then(([oauthResAfterDelete, basicAuthResAfterDelete]) => {
-                  should.not.exist(oauthResAfterDelete);
-                  should.not.exist(basicAuthResAfterDelete);
-                  done();
-                });
-            });
+          return userService.remove(user.id);
+        })
+        .then(res => {
+          should.exist(res);
+          return Promise.all([
+            credentialService.getCredential(user.username, 'oauth2'),
+            credentialService.getCredential(user.username, 'basic-auth')
+          ]);
+        })
+        .then(([oauthResAfterDelete, basicAuthResAfterDelete]) => {
+          should.not.exist(oauthResAfterDelete);
+          should.not.exist(basicAuthResAfterDelete);
         });
     });
 
-    it('should delete a credential', function (done) {
-      credentialService.insertCredential(user.username, 'oauth2')
-        .then(res => {
-          credentialService.removeCredential(user.username, 'oauth2')
-            .then(deleted => {
-              credentialService.getCredential(user.username, 'oauth2')
-                .then(resAfterDelete => {
-                  done();
-                });
-            });
-        });
+    it('should delete a credential', () => {
+      return credentialService.insertCredential(user.username, 'oauth2').then(res => {
+        should.exist(res);
+        return credentialService.removeCredential(user.username, 'oauth2');
+      }).then(deleted => {
+        should(deleted).be.equal(1);
+        return credentialService.getCredential(user.username, 'oauth2');
+      }).then(resAfterDelete => should.not.exist(resAfterDelete));
     });
   });
 
-  describe('Credential Property tests', function () {
+  describe('Credential Property tests', () => {
     const originalModelConfig = config.models.credentials;
     const username = 'someUser';
     const _credential = {
@@ -269,7 +208,7 @@ describe('Credential service tests', function () {
       someProperty: 'propVal'
     };
 
-    before(function (done) {
+    before(() => {
       config.models.credentials.oauth2 = {
         passwordKey: 'secret',
         autoGeneratePassword: true,
@@ -280,147 +219,85 @@ describe('Credential service tests', function () {
         }
       };
 
-      db.flushdbAsync()
-        .then(function (didSucceed) {
-          if (!didSucceed) {
-            console.log('Failed to flush the database');
-          }
-          done();
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
-        });
+      return db.flushdbAsync();
     });
 
-    after(function (done) {
+    after(() => {
       config.models.credentials = originalModelConfig;
-      done();
     });
 
-    it('should not insert a credential with scopes if the scopes are not defined', function (done) {
-      credentialService
-        .insertCredential(username, 'oauth2', _credential)
-        .then(function (newCredential) {
-          should.not.exist(newCredential);
-          done();
-        })
-        .catch(function (err) {
-          should.exist(err);
-          err.message.should.eql('one or more scopes don\'t exist');
-          done();
+    it('should not insert a credential with scopes if the scopes are not defined', () => {
+      return should(credentialService.insertCredential(username, 'oauth2', _credential))
+        .be.rejectedWith('one or more scopes don\'t exist');
+    });
+
+    it('should insert a credential with scopes if the scopes are defined', () => {
+      return credentialService.insertScopes('someScope')
+        .then(() => credentialService.insertCredential(username, 'oauth2', _credential))
+        .then((newCredential) => {
+          should.exist(newCredential);
+          newCredential.isActive.should.eql(true);
+          should.exist(newCredential.scopes);
+          newCredential.scopes.should.eql(['someScope']);
+          newCredential.someProperty.should.eql('propVal');
+          newCredential.otherProperty.should.eql('someDefaultValue');
+          should.not.exist(newCredential.secret);
         });
     });
 
-    it('should insert a credential with scopes if the scopes are defined', function (done) {
-      credentialService.insertScopes('someScope')
-        .then(() => {
-          credentialService
-            .insertCredential(username, 'oauth2', _credential)
-            .then(function (newCredential) {
-              should.exist(newCredential);
-              newCredential.isActive.should.eql(true);
-              should.exist(newCredential.scopes);
-              newCredential.scopes.should.eql(['someScope']);
-              newCredential.someProperty.should.eql('propVal');
-              newCredential.otherProperty.should.eql('someDefaultValue');
-              should.not.exist(newCredential.secret);
-              done();
-            })
-            .catch(function (err) {
-              should.not.exist(err);
-              done();
-            });
-        });
-    });
-
-    it('should add scopes to existing credential if the scopes are defined', function (done) {
-      credentialService.insertScopes(['someScope1', 'someScope2', 'someScope3', 'someOtherOne'])
-        .then(() => {
-          credentialService
-            .addScopesToCredential(username, 'oauth2', ['someScope1', 'someScope2', 'someScope3', 'someOtherOne'])
-            .then(function (res) {
-              credentialService
-                .getCredential(username, 'oauth2')
-                .then(function (cred) {
-                  should.exist(cred);
-                  should.exist(cred.scopes);
-                  cred.scopes.should.containEql(_credential.scopes);
-                  cred.scopes.should.containEql('someScope1');
-                  cred.scopes.should.containEql('someScope2');
-                  cred.scopes.should.containEql('someScope3');
-                  cred.scopes.should.containEql('someOtherOne');
-                  cred.isActive.should.eql(true);
-                  done();
-                });
-            })
-            .catch(function (err) {
-              should.not.exist(err);
-              done();
-            });
-        });
-    });
-
-    it('should remove scopes from existing credential', function (done) {
-      credentialService
-        .removeScopesFromCredential(username, 'oauth2', ['someScope2', 'someScope3'])
-        .then(function (res) {
+    it('should add scopes to existing credential if the scopes are defined', () => {
+      return credentialService.insertScopes(['someScope1', 'someScope2', 'someScope3', 'someOtherOne'])
+        .then(() => credentialService.addScopesToCredential(username, 'oauth2', ['someScope1', 'someScope2', 'someScope3', 'someOtherOne']))
+        .then((res) => {
           credentialService
             .getCredential(username, 'oauth2')
-            .then(function (cred) {
+            .then((cred) => {
               should.exist(cred);
               should.exist(cred.scopes);
               cred.scopes.should.containEql(_credential.scopes);
               cred.scopes.should.containEql('someScope1');
-              cred.scopes.should.not.containEql('someScope2');
-              cred.scopes.should.not.containEql('someScope3');
-              cred.isActive.should.eql(true);
-              done();
-            });
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
-        });
-    });
-
-    it('should remove scopes from credential if the scope is deleted', function (done) {
-      credentialService
-        .removeScopes(['someScope1', 'someScope'])
-        .then(function (res) {
-          credentialService
-            .getCredential(username, 'oauth2')
-            .then(function (cred) {
-              should.exist(cred);
-              should.exist(cred.scopes);
+              cred.scopes.should.containEql('someScope2');
+              cred.scopes.should.containEql('someScope3');
               cred.scopes.should.containEql('someOtherOne');
-              cred.scopes.should.not.containEql('someScope1');
-              cred.scopes.should.not.containEql('someScope');
               cred.isActive.should.eql(true);
-              done();
             });
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
         });
     });
 
-    it('should not add scopes to existing credential if the scopes are not defined', function (done) {
-      credentialService
-        .addScopesToCredential(username, 'oauth2', 'undefinedScope')
-        .then(function (res) {
-          should.not.exist(res);
-          done();
-        })
-        .catch(function (err) {
-          should.exist(err);
-          err.message.should.eql('one or more scopes don\'t exist');
-          done();
+    it('should remove scopes from existing credential', () => {
+      return credentialService
+        .removeScopesFromCredential(username, 'oauth2', ['someScope2', 'someScope3'])
+        .then(() => credentialService.getCredential(username, 'oauth2'))
+        .then((cred) => {
+          should.exist(cred);
+          should.exist(cred.scopes);
+          cred.scopes.should.containEql(_credential.scopes);
+          cred.scopes.should.containEql('someScope1');
+          cred.scopes.should.not.containEql('someScope2');
+          cred.scopes.should.not.containEql('someScope3');
+          cred.isActive.should.eql(true);
         });
     });
 
-    it('should use default property if not defined', function (done) {
+    it('should remove scopes from credential if the scope is deleted', () => {
+      return credentialService.removeScopes(['someScope1', 'someScope'])
+        .then(() => credentialService.getCredential(username, 'oauth2'))
+        .then((cred) => {
+          should.exist(cred);
+          should.exist(cred.scopes);
+          cred.scopes.should.containEql('someOtherOne');
+          cred.scopes.should.not.containEql('someScope1');
+          cred.scopes.should.not.containEql('someScope');
+          cred.isActive.should.eql(true);
+        });
+    });
+
+    it('should not add scopes to existing credential if the scopes are not defined', () => {
+      return should(credentialService.addScopesToCredential(username, 'oauth2', 'undefinedScope'))
+        .be.rejectedWith('one or more scopes don\'t exist');
+    });
+
+    it('should use default property if not defined', () => {
       const username2 = 'otherUser';
       const cred = {
         secret: 'password',
@@ -428,9 +305,9 @@ describe('Credential service tests', function () {
         someProperty: 'propVal'
       };
 
-      credentialService
+      return credentialService
         .insertCredential(username2, 'oauth2', cred)
-        .then(function (newCredential) {
+        .then((newCredential) => {
           should.exist(newCredential);
           newCredential.isActive.should.eql(true);
           should.exist(newCredential.scopes);
@@ -438,69 +315,39 @@ describe('Credential service tests', function () {
           newCredential.someProperty.should.eql('propVal');
           should.not.exist(newCredential.secret);
           newCredential.otherProperty.should.eql('someDefaultValue');
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should not create credential if a required property is not passed in', function (done) {
+    it('should not create credential if a required property is not passed in', () => {
       const username3 = 'anotherUser';
       const cred = {
         secret: 'password',
         scopes: 'someScope'
       };
 
-      credentialService
-        .insertCredential(username3, 'oauth2', cred)
-        .then(function () {
-          throw new Error('test failed');
-        })
-        .catch(function (err) {
-          should.exist(err);
-          err.message.should.eql('someProperty is required');
-          credentialService.getCredential(username3, 'oauth2')
-            .then(credential => {
-              should.not.exist(credential);
-              done();
-            })
-            .catch(err => {
-              should.not.exist(err);
-              done();
-            });
-        });
+      return should(credentialService
+        .insertCredential(username3, 'oauth2', cred))
+        .be.rejectedWith('someProperty is required')
+        .then(() => credentialService.getCredential(username3, 'oauth2'))
+        .then(credential => should.not.exist(credential));
     });
 
-    it('should not update credential with an update to an immutable property', function (done) {
-      credentialService
-        .updateCredential(username, 'oauth2', { someProperty: 'something' })
-        .then(function () {
-          throw new Error('test failed');
-        })
-        .catch(function (err) {
-          should.exist(err);
-          err.message.should.eql('someProperty is immutable');
-          credentialService.getCredential(username, 'oauth2')
-            .then(credential => {
-              should.exist(credential);
-              done();
-            });
-        });
+    it('should not update credential with an update to an immutable property', () => {
+      return should(credentialService.updateCredential(username, 'oauth2', { someProperty: 'something' }))
+        .be.rejectedWith('someProperty is immutable')
+        .then(() => credentialService.getCredential(username, 'oauth2'))
+        .then(credential => should.exist(credential));
     });
 
-    it('should not update credential when no properties are specified', function (done) {
-      credentialService
+    it('should not update credential when no properties are specified', () => {
+      return credentialService
         .updateCredential(username, 'oauth2', {})
-        .then(function (newCredential) {
+        .then((newCredential) => {
           should.not.exist(newCredential);
-          credentialService.getCredential(username, 'oauth2')
+          return credentialService.getCredential(username, 'oauth2')
             .then(credential => {
               should.exist(credential);
-              done();
             });
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
         });
     });
   });

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -32,16 +32,16 @@ describe('Credential service tests', function () {
       };
 
       db.flushdbAsync()
-      .then(function (didSucceed) {
-        if (!didSucceed) {
-          console.log('Failed to flush the database');
-        }
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+        .then(function (didSucceed) {
+          if (!didSucceed) {
+            console.log('Failed to flush the database');
+          }
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     after(function (done) {
@@ -55,16 +55,16 @@ describe('Credential service tests', function () {
       };
 
       credentialService
-      .insertCredential(username, 'oauth2', _credential)
-      .then(function (newCredential) {
-        should.exist(newCredential);
-        credential = Object.assign(newCredential, _credential);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+        .insertCredential(username, 'oauth2', _credential)
+        .then(function (newCredential) {
+          should.exist(newCredential);
+          credential = Object.assign(newCredential, _credential);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     it('should not insert a credential that already exists', function (done) {
@@ -73,32 +73,32 @@ describe('Credential service tests', function () {
       };
 
       credentialService
-      .insertCredential(username, 'oauth2', _credential)
-      .then(function (newCredential) {
-        should.not.exist(newCredential);
-        done();
-      })
-      .catch(function (err) {
-        should.exist(err);
-        done();
-      });
+        .insertCredential(username, 'oauth2', _credential)
+        .then(function (newCredential) {
+          should.not.exist(newCredential);
+          done();
+        })
+        .catch(function (err) {
+          should.exist(err);
+          done();
+        });
     });
 
     it('should insert a credential without password specified if autoGeneratePassword is set to true', function (done) {
       const _credential = {};
 
       credentialService
-      .insertCredential('someUsername', 'oauth2', _credential)
-      .then(function (newCredential) {
-        should.exist(newCredential);
-        should.exist(newCredential.secret);
-        newCredential.secret.length.should.greaterThanOrEqual(10);
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+        .insertCredential('someUsername', 'oauth2', _credential)
+        .then(function (newCredential) {
+          should.exist(newCredential);
+          should.exist(newCredential.secret);
+          newCredential.secret.length.should.greaterThanOrEqual(10);
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     it('should insert a credential with id but different type that already exists', function (done) {
@@ -107,66 +107,62 @@ describe('Credential service tests', function () {
       };
 
       credentialService
-      .insertCredential(username, 'basic-auth', _credential)
-      .then(function (newCredential) {
-        should.exist(newCredential);
-        newCredential.isActive.should.eql(true);
-        done();
-      })
-      .catch(done);
+        .insertCredential(username, 'basic-auth', _credential)
+        .then(function (newCredential) {
+          should.exist(newCredential);
+          newCredential.isActive.should.eql(true);
+          done();
+        })
+        .catch(done);
     });
 
     it('should get a credential', function (done) {
       credentialService
-      .getCredential(username, 'oauth2')
-      .then(function (cred) {
-        should.exist(cred);
-        should.not.exist(cred.secret);
-        credential.isActive.should.eql(true);
-        done();
-      })
-      .catch(done);
+        .getCredential(username, 'oauth2')
+        .then(function (cred) {
+          should.exist(cred);
+          should.not.exist(cred.secret);
+          credential.isActive.should.eql(true);
+          done();
+        })
+        .catch(done);
     });
 
     it('should deactivate a credential', function (done) {
       credentialService
-      .deactivateCredential(username, 'oauth2')
-      .then(function (res) {
-        should.exist(res);
-        res.should.eql(true);
-
-        credentialService
-        .getCredential(username, 'oauth2')
-        .then(function (cred) {
-          should.exist(cred);
-          should.not.exist(cred.secret);
-          cred.isActive.should.eql(false);
-          done();
-        });
-      })
-      .catch(done);
+        .deactivateCredential(username, 'oauth2')
+        .then(function (res) {
+          credentialService
+            .getCredential(username, 'oauth2')
+            .then(function (cred) {
+              should.exist(cred);
+              should.not.exist(cred.secret);
+              cred.isActive.should.eql(false);
+              done();
+            });
+        })
+        .catch(done);
     });
 
     it('should reactivate a credential', function (done) {
       credentialService
-      .activateCredential(username, 'oauth2')
-      .then(function (res) {
-        should.exist(res);
-        res.should.eql(true);
+        .activateCredential(username, 'oauth2')
+        .then(function (res) {
+          should.exist(res);
 
-        credentialService
-        .getCredential(username, 'oauth2')
-        .then(function (cred) {
-          should.exist(cred);
-          should.not.exist(cred.secret);
-          cred.isActive.should.eql(true);
+          credentialService
+            .getCredential(username, 'oauth2')
+            .then(function (cred) {
+              should.exist(cred);
+              should.not.exist(cred.secret);
+              cred.isActive.should.eql(true);
+              done();
+            });
+        })
+        .catch(function (err) {
+          should.not.exist(err);
           done();
         });
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
     });
   });
 
@@ -199,30 +195,30 @@ describe('Credential service tests', function () {
       };
 
       db.flushdbAsync()
-      .then(function (didSucceed) {
-        if (!didSucceed) {
-          console.log('Failed to flush the database');
-        }
-        userService
-        .insert(user)
-        .then(function (newUser) {
-          should.exist(newUser);
-          user = newUser;
-          credentialService.insertCredential(user.username, 'oauth2')
-          .then((oauthCred) => {
-            should.exist(oauthCred.secret);
-            credentialService.insertCredential(user.username, 'basic-auth')
-            .then((basicAuthCred) => {
-              should.exist(basicAuthCred.password);
-              done();
+        .then(function (didSucceed) {
+          if (!didSucceed) {
+            console.log('Failed to flush the database');
+          }
+          userService
+            .insert(user)
+            .then(function (newUser) {
+              should.exist(newUser);
+              user = newUser;
+              credentialService.insertCredential(user.username, 'oauth2')
+                .then((oauthCred) => {
+                  should.exist(oauthCred.secret);
+                  credentialService.insertCredential(user.username, 'basic-auth')
+                    .then((basicAuthCred) => {
+                      should.exist(basicAuthCred.password);
+                      done();
+                    });
+                });
             });
-          });
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
         });
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
     });
 
     after(function (done) {
@@ -231,40 +227,36 @@ describe('Credential service tests', function () {
     });
 
     it('should delete all credentials associated with a user when user is deleted', function (done) {
-      Promise.all([ credentialService.getCredential(user.username, 'oauth2'),
-        credentialService.getCredential(user.username, 'basic-auth') ])
-      .then(([oauthRes, basicAuthRes]) => {
-        should.exist(oauthRes); // Check to confirm the credentials exist
-        should.exist(basicAuthRes);
-        return userService.remove(user.id)
-        .then(res => {
-          should.exist(res);
-          res.should.eql(true);
-          return Promise.all([ credentialService.getCredential(user.username, 'oauth2'),
-            credentialService.getCredential(user.username, 'basic-auth') ])
-          .then(([oauthResAfterDelete, basicAuthResAfterDelete]) => {
-            should.not.exist(oauthResAfterDelete);
-            should.not.exist(basicAuthResAfterDelete);
-            done();
-          });
+      Promise.all([credentialService.getCredential(user.username, 'oauth2'),
+        credentialService.getCredential(user.username, 'basic-auth')])
+        .then(([oauthRes, basicAuthRes]) => {
+          should.exist(oauthRes); // Check to confirm the credentials exist
+          should.exist(basicAuthRes);
+          return userService.remove(user.id)
+            .then(res => {
+              should.exist(res);
+              return Promise.all([credentialService.getCredential(user.username, 'oauth2'),
+                credentialService.getCredential(user.username, 'basic-auth')])
+                .then(([oauthResAfterDelete, basicAuthResAfterDelete]) => {
+                  should.not.exist(oauthResAfterDelete);
+                  should.not.exist(basicAuthResAfterDelete);
+                  done();
+                });
+            });
         });
-      });
     });
 
     it('should delete a credential', function (done) {
       credentialService.insertCredential(user.username, 'oauth2')
-      .then(res => {
-        should.exist(res);
-        credentialService.removeCredential(user.username, 'oauth2')
-        .then(deleted => {
-          deleted.should.eql(true);
-          credentialService.getCredential(user.username, 'oauth2')
-          .then(resAfterDelete => {
-            should.not.exist(resAfterDelete);
-            done();
-          });
+        .then(res => {
+          credentialService.removeCredential(user.username, 'oauth2')
+            .then(deleted => {
+              credentialService.getCredential(user.username, 'oauth2')
+                .then(resAfterDelete => {
+                  done();
+                });
+            });
         });
-      });
     });
   });
 
@@ -289,16 +281,16 @@ describe('Credential service tests', function () {
       };
 
       db.flushdbAsync()
-      .then(function (didSucceed) {
-        if (!didSucceed) {
-          console.log('Failed to flush the database');
-        }
-        done();
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+        .then(function (didSucceed) {
+          if (!didSucceed) {
+            console.log('Failed to flush the database');
+          }
+          done();
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
 
     after(function (done) {
@@ -308,130 +300,124 @@ describe('Credential service tests', function () {
 
     it('should not insert a credential with scopes if the scopes are not defined', function (done) {
       credentialService
-      .insertCredential(username, 'oauth2', _credential)
-      .then(function (newCredential) {
-        should.not.exist(newCredential);
-        done();
-      })
-      .catch(function (err) {
-        should.exist(err);
-        err.message.should.eql('one or more scopes don\'t exist');
-        done();
-      });
+        .insertCredential(username, 'oauth2', _credential)
+        .then(function (newCredential) {
+          should.not.exist(newCredential);
+          done();
+        })
+        .catch(function (err) {
+          should.exist(err);
+          err.message.should.eql('one or more scopes don\'t exist');
+          done();
+        });
     });
 
     it('should insert a credential with scopes if the scopes are defined', function (done) {
       credentialService.insertScopes('someScope')
-      .then(() => {
-        credentialService
-        .insertCredential(username, 'oauth2', _credential)
-        .then(function (newCredential) {
-          should.exist(newCredential);
-          newCredential.isActive.should.eql(true);
-          should.exist(newCredential.scopes);
-          newCredential.scopes.should.eql(['someScope']);
-          newCredential.someProperty.should.eql('propVal');
-          newCredential.otherProperty.should.eql('someDefaultValue');
-          should.not.exist(newCredential.secret);
-          done();
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
+        .then(() => {
+          credentialService
+            .insertCredential(username, 'oauth2', _credential)
+            .then(function (newCredential) {
+              should.exist(newCredential);
+              newCredential.isActive.should.eql(true);
+              should.exist(newCredential.scopes);
+              newCredential.scopes.should.eql(['someScope']);
+              newCredential.someProperty.should.eql('propVal');
+              newCredential.otherProperty.should.eql('someDefaultValue');
+              should.not.exist(newCredential.secret);
+              done();
+            })
+            .catch(function (err) {
+              should.not.exist(err);
+              done();
+            });
         });
-      });
     });
 
     it('should add scopes to existing credential if the scopes are defined', function (done) {
-      credentialService.insertScopes([ 'someScope1', 'someScope2', 'someScope3', 'someOtherOne' ])
-      .then(() => {
-        credentialService
-        .addScopesToCredential(username, 'oauth2', [ 'someScope1', 'someScope2', 'someScope3', 'someOtherOne' ])
-        .then(function (res) {
-          res.should.eql(true);
-
+      credentialService.insertScopes(['someScope1', 'someScope2', 'someScope3', 'someOtherOne'])
+        .then(() => {
           credentialService
-          .getCredential(username, 'oauth2')
-          .then(function (cred) {
-            should.exist(cred);
-            should.exist(cred.scopes);
-            cred.scopes.should.containEql(_credential.scopes);
-            cred.scopes.should.containEql('someScope1');
-            cred.scopes.should.containEql('someScope2');
-            cred.scopes.should.containEql('someScope3');
-            cred.scopes.should.containEql('someOtherOne');
-            cred.isActive.should.eql(true);
-            done();
-          });
-        })
-        .catch(function (err) {
-          should.not.exist(err);
-          done();
+            .addScopesToCredential(username, 'oauth2', ['someScope1', 'someScope2', 'someScope3', 'someOtherOne'])
+            .then(function (res) {
+              credentialService
+                .getCredential(username, 'oauth2')
+                .then(function (cred) {
+                  should.exist(cred);
+                  should.exist(cred.scopes);
+                  cred.scopes.should.containEql(_credential.scopes);
+                  cred.scopes.should.containEql('someScope1');
+                  cred.scopes.should.containEql('someScope2');
+                  cred.scopes.should.containEql('someScope3');
+                  cred.scopes.should.containEql('someOtherOne');
+                  cred.isActive.should.eql(true);
+                  done();
+                });
+            })
+            .catch(function (err) {
+              should.not.exist(err);
+              done();
+            });
         });
-      });
     });
 
     it('should remove scopes from existing credential', function (done) {
       credentialService
-      .removeScopesFromCredential(username, 'oauth2', [ 'someScope2', 'someScope3' ])
-      .then(function (res) {
-        res.should.eql(true);
-
-        credentialService
-        .getCredential(username, 'oauth2')
-        .then(function (cred) {
-          should.exist(cred);
-          should.exist(cred.scopes);
-          cred.scopes.should.containEql(_credential.scopes);
-          cred.scopes.should.containEql('someScope1');
-          cred.scopes.should.not.containEql('someScope2');
-          cred.scopes.should.not.containEql('someScope3');
-          cred.isActive.should.eql(true);
+        .removeScopesFromCredential(username, 'oauth2', ['someScope2', 'someScope3'])
+        .then(function (res) {
+          credentialService
+            .getCredential(username, 'oauth2')
+            .then(function (cred) {
+              should.exist(cred);
+              should.exist(cred.scopes);
+              cred.scopes.should.containEql(_credential.scopes);
+              cred.scopes.should.containEql('someScope1');
+              cred.scopes.should.not.containEql('someScope2');
+              cred.scopes.should.not.containEql('someScope3');
+              cred.isActive.should.eql(true);
+              done();
+            });
+        })
+        .catch(function (err) {
+          should.not.exist(err);
           done();
         });
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
     });
 
     it('should remove scopes from credential if the scope is deleted', function (done) {
       credentialService
-      .removeScopes(['someScope1', 'someScope'])
-      .then(function (res) {
-        res.should.eql(true);
-
-        credentialService
-        .getCredential(username, 'oauth2')
-        .then(function (cred) {
-          should.exist(cred);
-          should.exist(cred.scopes);
-          cred.scopes.should.containEql('someOtherOne');
-          cred.scopes.should.not.containEql('someScope1');
-          cred.scopes.should.not.containEql('someScope');
-          cred.isActive.should.eql(true);
+        .removeScopes(['someScope1', 'someScope'])
+        .then(function (res) {
+          credentialService
+            .getCredential(username, 'oauth2')
+            .then(function (cred) {
+              should.exist(cred);
+              should.exist(cred.scopes);
+              cred.scopes.should.containEql('someOtherOne');
+              cred.scopes.should.not.containEql('someScope1');
+              cred.scopes.should.not.containEql('someScope');
+              cred.isActive.should.eql(true);
+              done();
+            });
+        })
+        .catch(function (err) {
+          should.not.exist(err);
           done();
         });
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
     });
 
     it('should not add scopes to existing credential if the scopes are not defined', function (done) {
       credentialService
-      .addScopesToCredential(username, 'oauth2', 'undefinedScope')
-      .then(function (res) {
-        should.not.exist(res);
-        done();
-      })
-      .catch(function (err) {
-        should.exist(err);
-        err.message.should.eql('one or more scopes don\'t exist');
-        done();
-      });
+        .addScopesToCredential(username, 'oauth2', 'undefinedScope')
+        .then(function (res) {
+          should.not.exist(res);
+          done();
+        })
+        .catch(function (err) {
+          should.exist(err);
+          err.message.should.eql('one or more scopes don\'t exist');
+          done();
+        });
     });
 
     it('should use default property if not defined', function (done) {
@@ -443,18 +429,18 @@ describe('Credential service tests', function () {
       };
 
       credentialService
-      .insertCredential(username2, 'oauth2', cred)
-      .then(function (newCredential) {
-        should.exist(newCredential);
-        newCredential.isActive.should.eql(true);
-        should.exist(newCredential.scopes);
-        newCredential.scopes.should.eql(['someOtherOne']);
-        newCredential.someProperty.should.eql('propVal');
-        should.not.exist(newCredential.secret);
-        newCredential.otherProperty.should.eql('someDefaultValue');
-        done();
-      })
-      .catch(done);
+        .insertCredential(username2, 'oauth2', cred)
+        .then(function (newCredential) {
+          should.exist(newCredential);
+          newCredential.isActive.should.eql(true);
+          should.exist(newCredential.scopes);
+          newCredential.scopes.should.eql(['someOtherOne']);
+          newCredential.someProperty.should.eql('propVal');
+          should.not.exist(newCredential.secret);
+          newCredential.otherProperty.should.eql('someDefaultValue');
+          done();
+        })
+        .catch(done);
     });
 
     it('should not create credential if a required property is not passed in', function (done) {
@@ -465,57 +451,57 @@ describe('Credential service tests', function () {
       };
 
       credentialService
-      .insertCredential(username3, 'oauth2', cred)
-      .then(function () {
-        throw new Error('test failed');
-      })
-      .catch(function (err) {
-        should.exist(err);
-        err.message.should.eql('someProperty is required');
-        credentialService.getCredential(username3, 'oauth2')
-          .then(credential => {
-            should.not.exist(credential);
-            done();
-          })
-          .catch(err => {
-            should.not.exist(err);
-            done();
-          });
-      });
+        .insertCredential(username3, 'oauth2', cred)
+        .then(function () {
+          throw new Error('test failed');
+        })
+        .catch(function (err) {
+          should.exist(err);
+          err.message.should.eql('someProperty is required');
+          credentialService.getCredential(username3, 'oauth2')
+            .then(credential => {
+              should.not.exist(credential);
+              done();
+            })
+            .catch(err => {
+              should.not.exist(err);
+              done();
+            });
+        });
     });
 
     it('should not update credential with an update to an immutable property', function (done) {
       credentialService
-      .updateCredential(username, 'oauth2', { someProperty: 'something' })
-      .then(function () {
-        throw new Error('test failed');
-      })
-      .catch(function (err) {
-        should.exist(err);
-        err.message.should.eql('someProperty is immutable');
-        credentialService.getCredential(username, 'oauth2')
-          .then(credential => {
-            should.exist(credential);
-            done();
-          });
-      });
+        .updateCredential(username, 'oauth2', { someProperty: 'something' })
+        .then(function () {
+          throw new Error('test failed');
+        })
+        .catch(function (err) {
+          should.exist(err);
+          err.message.should.eql('someProperty is immutable');
+          credentialService.getCredential(username, 'oauth2')
+            .then(credential => {
+              should.exist(credential);
+              done();
+            });
+        });
     });
 
     it('should not update credential when no properties are specified', function (done) {
       credentialService
-      .updateCredential(username, 'oauth2', {})
-      .then(function (newCredential) {
-        should.not.exist(newCredential);
-        credentialService.getCredential(username, 'oauth2')
-          .then(credential => {
-            should.exist(credential);
-            done();
-          });
-      })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
+        .updateCredential(username, 'oauth2', {})
+        .then(function (newCredential) {
+          should.not.exist(newCredential);
+          credentialService.getCredential(username, 'oauth2')
+            .then(credential => {
+              should.exist(credential);
+              done();
+            });
+        })
+        .catch(function (err) {
+          should.not.exist(err);
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
Connects #361 

This pull request will change several things in the credential service. As I'll be working on this soon due to #361 , it's good to have a better base.

1. Reduce promise nesting (which is always bad)
2. DRY some functions and reuse them where possible
3. Throw errors instead of rejecting promises (an exception in a promise *IS* a rejection)

This is easier to review disabling whitespace diffs: https://github.com/ExpressGateway/express-gateway/pull/485/files?w=1