### PR TITLE
Basic Migrations command

### DIFF
--- a/migrations/1509389756098-credential-username-userid-transform.js
+++ b/migrations/1509389756098-credential-username-userid-transform.js
@@ -1,0 +1,44 @@
+const log = require('migrate/lib/log');
+
+const userService = require('../lib/services/consumers/user.service');
+const credentialService = require('../lib/services/credentials/credential.service');
+
+/*
+  This migration will use the services to deactivate all credentials that are still active and coupled to the username
+  instead of the consumer ID. For each deactived credential, an identical new one will be issued and linked to the user
+  id, making sure the clients will continue to work correctly, as the Admin API's been already modified to change the
+  way it looks up the data.
+*/
+
+module.exports.up = function (next) {
+  userService.findAll() // Grab all the users
+    .then(({ users }) => {
+      const userPromises = users.map((user) => {
+        log('Processing user', user.username);
+
+        return credentialService.getCredentials(user.username) // Grab credentials coupled to the user name
+          .then((credentials) => {
+            const credentialPromises = credentials.filter(c => c.isActive).map((credential) => { // Filter the ones that are still active
+              log('Processing credential', `${credential.type}, user: ${user.username}`);
+
+              return credentialService
+                .deactivateCredential(user.username, credential.type) // Deactivate the credential
+                .then(() => log('Processed credential', `${user.username} credential deactivated successfully.`))
+                .then(() => credentialService.insertCredential(user.id, credential.type, credential)
+                  .catch(err => log.error('Credential existing already', err)) // Create a new one with the ID instead of the username
+                )
+                .then(() => log('Created credential', `${user.username} credential migrated successfully to ${user.id}`))
+                .catch(next);
+            });
+
+            return Promise.all(credentialPromises);
+          });
+      });
+
+      return Promise.all(userPromises).then(() => next()); // Everything is awesome!
+    });
+};
+
+module.exports.down = function (next) {
+  throw new Error('We\'re sorry — we can\'t make this happen');
+};

--- a/migrations/1509389756098-credential-username-userid-transform.js
+++ b/migrations/1509389756098-credential-username-userid-transform.js
@@ -10,8 +10,8 @@ const credentialService = require('../lib/services/credentials/credential.servic
   way it looks up the data.
 */
 
-module.exports.up = function (next) {
-  userService.findAll() // Grab all the users
+module.exports.up = function () {
+  return userService.findAll() // Grab all the users
     .then(({ users }) => {
       const userPromises = users.map((user) => {
         log('Processing user', user.username);
@@ -27,16 +27,15 @@ module.exports.up = function (next) {
                 .then(() => credentialService.insertCredential(user.id, credential.type, credential)
                   .catch(err => log.error('Credential existing already', err)) // Create a new one with the ID instead of the username
                 )
-                .then(() => log('Created credential', `${user.username} credential migrated successfully to ${user.id}`))
-                .catch(next);
+                .then(() => log('Created credential', `${user.username} credential migrated successfully to ${user.id}`));
             });
 
             return Promise.all(credentialPromises);
           });
       });
 
-      return Promise.all(userPromises).then(() => next()); // Everything is awesome!
-    });
+      return Promise.all(userPromises); // Everything is awesome!
+    }).then(() => { });
 };
 
 module.exports.down = function (next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -655,7 +655,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
       "requires": {
         "graceful-readlink": "1.0.1"
       }
@@ -3020,8 +3019,7 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "grouped-queue": {
       "version": "0.3.3",
@@ -4098,6 +4096,20 @@
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
         "regex-cache": "0.4.4"
+      }
+    },
+    "migrate": {
+      "version": "1.0.0-2",
+      "resolved": "https://registry.npmjs.org/migrate/-/migrate-1.0.0-2.tgz",
+      "integrity": "sha1-zAa+7iJv5+9+Q42tvhhpiXg77Mo=",
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "dateformat": "2.0.0",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "slug": "0.9.1"
       }
     },
     "mime": {
@@ -7060,6 +7072,14 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
+    "slug": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
+      "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
+      "requires": {
+        "unicode": "10.0.0"
+      }
+    },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
@@ -7652,6 +7672,11 @@
         "inherits": "2.0.3",
         "xtend": "4.0.1"
       }
+    },
+    "unicode": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-10.0.0.tgz",
+      "integrity": "sha1-5dUcHbk7bHGguHngsMSvfm/faI4="
     },
     "unified": {
       "version": "6.1.5",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "has-flag": "2.0.0",
     "http-proxy": "1.16.2",
     "js-yaml": "^3.10.0",
+    "migrate": "^1.0.0-2",
     "minimatch": "^3.0.4",
     "oauth2orize": "^1.10.0",
     "parent-require": "^1.0.0",

--- a/test/migrations/credential-username-userid-transform.js
+++ b/test/migrations/credential-username-userid-transform.js
@@ -1,0 +1,55 @@
+const migrate = require('migrate');
+const tmp = require('tmp');
+const db = require('../../lib/db')();
+const { assert } = require('chai');
+const userService = require('../../lib/services/consumers/user.service');
+const credentialService = require('../../lib/services/credentials/credential.service');
+
+describe('Migrations', () => {
+  describe('Username -> UserID credential transform', () => {
+    let tmpFile;
+    let userId;
+    let oldCredential;
+    before('I insert some credentials by user ID', () => {
+      return userService.insert({
+        username: 'vncz',
+        firstname: 'Vincenzo',
+        lastname: 'Chianese'
+      }).then((user) => {
+        userId = user.id;
+        return credentialService
+          .insertCredential('vncz', 'basic-auth', {})
+          .then(() => credentialService.getCredentials('vncz'))
+          .then((creds) => { oldCredential = creds[0]; });
+      });
+    });
+
+    before('I then run the migration script', (done) => {
+      tmpFile = tmp.fileSync();
+      migrate.load({ stateStore: tmpFile.name }, (err, set) => {
+        if (err) {
+          return done(err);
+        }
+        set.up('1509389756098-credential-username-userid-transform.js', done);
+      });
+    });
+
+    it('should not find any active credential with user name any more', () => {
+      return credentialService.getCredentials('vncz').then((credentials) => {
+        assert.lengthOf(credentials.filter(c => c.isActive), 0);
+      });
+    });
+
+    it('should find an active credential with user ID and SAME hashed password', () => {
+      return credentialService.getCredentials(userId).then((credentials) => {
+        assert.lengthOf(credentials.filter(c => c.isActive), 1);
+        assert.equal(credentials[0].password, oldCredential.password);
+      });
+    });
+
+    after(() => {
+      tmpFile.removeCallback();
+      return db.flushdb();
+    });
+  });
+});

--- a/test/migrations/credential-username-userid-transform.js
+++ b/test/migrations/credential-username-userid-transform.js
@@ -10,7 +10,7 @@ describe('Migrations', () => {
     let tmpFile;
     let userId;
     let oldCredential;
-    before('I insert some credentials by user ID', () => {
+    before('I insert some credentials by user name', () => {
       return userService.insert({
         username: 'vncz',
         firstname: 'Vincenzo',


### PR DESCRIPTION
This pull request will introduce a migration mechanism for the gateway leveraging [node-migrate@next](https://npmjs.org/packages/migrate) module by Tj.

Connects #490
Connects #492 closes #492

Standing points:

- This module can track the ran migrations using a `.migrate` file or using a custom storage mechanism. Question is whether we want to use the file or store the things in Redis, for example.
If we keep them on Redis, you move the DB, you are ok. If you keep them on the file system you might re-run the migrations if you change the server. ✌️ 

- How do we make sure the users will run the migrations? I've checked Kong and they do not care. They rely on the fact that you read the change log and notice you've got a migration to run; therefore you run them. I'd stick with the same mechanism ✌️ 

- [x] Figure out a way to test the effects by this migration
~Integrate the migration command with the `eg` cmd line~ (we're not doing that)