### PR TITLE
Automate docker and npm publish part

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,36 @@ jobs:
       - run: npm install
       - run: npm test
 
+  deploy:
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/repo
+
+    steps:
+      - setup_remote_docker
+      - run: npm publish
+      - run: "docker build -t expressgateway/express-gateway:${CIRCLE_TAG} --build-arg VERSION=latest - < Dockerfile"
+      - run: |
+              "docker build -t expressgateway/express-gateway:${CIRCLE_TAG}-getting-started
+               --build-arg VERSION=latest --build-arg TYPE=getting-started - < Dockerfile"
+      - run: "docker tag expressgateway/express-gateway:${CIRCLE_TAG} expressgateway/express-gateway:latest"
+      - run: "docker tag expressgateway/express-gateway:${CIRCLE_TAG}-getting-started expressgateway/express-gateway:latest"
+      - run: "docker push expressgateway/express-gateway:${CIRCLE_TAG}"
+      - run: "docker push expressgateway/express-gateway:${CIRCLE_TAG}-getting-started"
+      - run: "docker push expressgateway/express-gateway:latest"
+      - run: "docker push expressgateway/express-gateway:latest-getting-started"
+
 workflows:
   version: 2
   build:
     jobs:
       - node-6
       - node-8
+      - deploy:
+          filters:
+            tags:
+              only: /^v\d\.\d\.\d/
+            branches:
+              only: master
+          requires:
+            - node-8

--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
     "test-all": "cross-env EG_CONFIG_DIR=test/config EG_DISABLE_CONFIG_WATCH=true mocha --recursive test --timeout 60000",
     "test:unit": "cross-env EG_CONFIG_DIR=test/config EG_DISABLE_CONFIG_WATCH=true mocha --recursive \"./test/{,!(e2e)/**/}*.test.js\" --timeout 5000",
     "test:e2e": "mocha --recursive test/e2e --timeout 60000",
-    "docker:create": "docker build -t expressgateway/express-gateway:v$npm_package_version --build-arg VERSION=$npm_package_version - < Dockerfile",
-    "docker-gs:create": "docker build -t expressgateway/express-gateway:v${npm_package_version}-getting-started --build-arg VERSION=$npm_package_version --build-arg TYPE=getting-started - < Dockerfile",
-    "docker:publish": "docker push expressgateway/express-gateway:v$npm_package_version",
-    "docker-gs:publish": "docker push expressgateway/express-gateway:v${npm_package_version}-getting-started",
     "mocha-istanbul": "nyc --reporter=lcov npm run test-all && nyc report --report=lcov > coverage.lcov && codecov"
   },
   "bin": {


### PR DESCRIPTION
This PR should hopefully allevieate the amount of work we have to do when we want to
release a new express-gateway version. 

It will listen on the master branch and if a new tag with vx.y.z pattern comes in, it will build and publish both npm package and docker images related, and update the 'latest' tag as well.

We need to set both docker and npm credentials through env variables (//cc @kevinswiber )

Unfortunately I can't test this properly without deploying something — so once merged we could give it a try on eg 1.4 or any bug fix that'll come along us.

Connects #495 closes #495 