### PR TITLE
Redis TLS from files

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -29,20 +29,17 @@ module.exports = function () {
   }
 
   // TLS for redis, allowing for TLS options to be specified as file paths.
-  if (Object.keys(redisOptions).includes('tls')) {
+  if (redisOptions.tls) {
     if (redisOptions.tls.keyFile) {
       redisOptions.tls.key = fs.readFileSync(redisOptions.tls.keyFile);
-      delete redisOptions.tls.keyFile;
     }
 
     if (redisOptions.tls.certFile) {
       redisOptions.tls.cert = fs.readFileSync(redisOptions.tls.certFile);
-      delete redisOptions.tls.certFile;
     }
 
     if (redisOptions.tls.caFile) {
       redisOptions.tls.ca = fs.readFileSync(redisOptions.tls.caFile);
-      delete redisOptions.tls.caFile;
     }
   }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,6 +2,7 @@ const logger = require('./logger').db;
 const redisCommands = require('redis-commands');
 require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
 const util = require('util');
+const fs = require('fs');
 let db;
 
 module.exports = function () {
@@ -25,6 +26,24 @@ module.exports = function () {
         obj[method + 'Async'] = util.promisify(obj[method]);
       }
     });
+  }
+
+  // TLS for redis, allowing for TLS options to be specified as file paths.
+  if (Object.keys(redisOptions).includes('tls')) {
+    if (redisOptions.tls.keyFile) {
+      redisOptions.tls.key = fs.readFileSync(redisOptions.tls.keyFile);
+      delete redisOptions.tls.keyFile;
+    }
+
+    if (redisOptions.tls.certFile) {
+      redisOptions.tls.cert = fs.readFileSync(redisOptions.tls.certFile);
+      delete redisOptions.tls.certFile;
+    }
+
+    if (redisOptions.tls.caFile) {
+      redisOptions.tls.ca = fs.readFileSync(redisOptions.tls.caFile);
+      delete redisOptions.tls.caFile;
+    }
   }
 
   db = redis.createClient(redisOptions);

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,79 @@
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+const sinon = require('sinon');
+const fakeredis = require('fakeredis');
+
+const dbPath = '../lib/db';
+const config = require('../lib/config');
+let originalSystemConfig = config.systemConfig;
+
+const clientKeyFile = path.join(__dirname, 'fixtures/certs/client', 'client.key');
+const clientCertFile = path.join(__dirname, 'fixtures/certs/client', 'client.crt');
+const chainFile = path.join(__dirname, 'fixtures/certs/chain', 'chain.pem');
+
+let db;
+
+describe('configured DB options', () => {
+  describe('TLS keyFile, certFile and caFile', function () {
+    before(() => {
+      sinon.spy(fakeredis, 'createClient');
+    });
+
+    beforeEach(() => {
+      originalSystemConfig = config.systemConfig;
+      delete require.cache[require.resolve(dbPath)];
+      db = require(dbPath);
+    });
+
+    afterEach(() => {
+      config.systemConfig = originalSystemConfig;
+    });
+
+    after(() => {
+      fakeredis.createClient.restore();
+    });
+
+    describe('when configured', () => {
+      it('loads certificates from specified paths', () => {
+        config.systemConfig.db.redis.tls = {
+          keyFile: clientKeyFile,
+          certFile: clientCertFile,
+          caFile: chainFile
+        };
+        assert(!config.systemConfig.db.redis.tls.key);
+        assert(!config.systemConfig.db.redis.tls.cert);
+        assert(!config.systemConfig.db.redis.tls.ca);
+
+        db();
+
+        assert.equal(
+          fakeredis.createClient.getCall(0).args[0].tls.key.toString(),
+          fs.readFileSync(clientKeyFile).toString()
+        );
+
+        assert.equal(
+          fakeredis.createClient.getCall(0).args[0].tls.cert.toString(),
+          fs.readFileSync(clientCertFile).toString()
+        );
+
+        assert.equal(
+          fakeredis.createClient.getCall(0).args[0].tls.ca.toString(),
+          fs.readFileSync(chainFile).toString()
+        );
+      });
+    });
+
+    describe('when not configured', () => {
+      it('does not load certificates from specified paths', () => {
+        config.systemConfig.db.redis.tls = {};
+
+        db();
+
+        assert(!fakeredis.createClient.getCall(0).args[0].tls.key);
+        assert(!fakeredis.createClient.getCall(0).args[0].tls.cert);
+        assert(!fakeredis.createClient.getCall(0).args[0].tls.ca);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Added ability to specify TLS key, cert and CA as file paths, with loading of files.

Note: Branch checked out from proxy options feature, which should be merged first.