### PR TITLE
Add node-6 dependency and checkout the code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - checkout
       - setup_remote_docker
       - run: npm publish
       - run: "docker build -t expressgateway/express-gateway:${CIRCLE_TAG} --build-arg VERSION=latest - < Dockerfile"
@@ -53,3 +54,4 @@ workflows:
               only: master
           requires:
             - node-8
+            - node-6


### PR DESCRIPTION
Follow up to #496 
Connects #495 

The PR will make sure to checkout the code before building images (or it won't work) and make sure *both* node6 and node 8 tests will pass before executing the job.