### PR TITLE
Fix/remove event listeners on server close

### DIFF
--- a/lib/gateway/server.js
+++ b/lib/gateway/server.js
@@ -6,10 +6,15 @@ const fs = require('fs');
 const path = require('path');
 const logger = require('../logger').gateway;
 const config = require('../config');
+const eventBus = require('../eventBus');
 
 module.exports.bootstrap = function (app) {
   const httpServer = config.gatewayConfig.http ? http.createServer(app) : null;
   const httpsServer = config.gatewayConfig.https && config.gatewayConfig.https.tls ? createTlsServer(config.gatewayConfig.https, app) : null;
+
+  addOnCloseEventHandlingToServer(httpServer);
+  addOnCloseEventHandlingToServer(httpsServer);
+
   return {
     httpServer,
     httpsServer
@@ -67,4 +72,12 @@ function createTlsServer (httpsConfig, app) {
   }
 
   return https.createServer(options, app);
+}
+
+function addOnCloseEventHandlingToServer (server) {
+  if (server) {
+    server.on('close', function () {
+      eventBus.removeAllListeners();
+    });
+  }
 }


### PR DESCRIPTION
Remove event listeners from eventBus on server close - much tidier and allows reuse of gateway in tests without the need for forking (Theory, not practiced).

Note: Based on "Redis TLS from files" PR and will rebase to master once ready.