### PR TITLE
Test refactor — do not hardcode values

### DIFF
--- a/test/cli/apps/deactivate.test.js
+++ b/test/cli/apps/deactivate.test.js
@@ -19,28 +19,24 @@ describe('eg apps deactivate', () => {
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
+      .then(createdUser => {
+        user = createdUser;
 
-      return adminHelper.admin.apps.create(user.id, {
-        name: 'appy1',
-        redirectUri: 'http://localhost:3000/cb'
+        return adminHelper.admin.apps.create(user.id, {
+          name: 'appy1',
+          redirectUri: 'http://localhost:3000/cb'
+        });
+      })
+      .then(createdApp => {
+        app1 = createdApp;
+        return adminHelper.admin.apps.create(user.id, {
+          name: 'appy2',
+          redirectUri: 'http://localhost:3000/cb'
+        });
+      })
+      .then(createdApp => {
+        app2 = createdApp;
       });
-    })
-    .then(createdApp => {
-      app1 = createdApp;
-      return adminHelper.admin.apps.create(user.id, {
-        name: 'appy2',
-        redirectUri: 'http://localhost:3000/cb'
-      });
-    })
-    .then(createdApp => {
-      app2 = createdApp;
-      return adminHelper.admin.apps.create(user.id, {
-        name: 'appy2',
-        redirectUri: 'http://localhost:3000/cb'
-      });
-    });
   });
 
   afterEach(() => {

--- a/test/e2e/key-auth.e2e.test.js
+++ b/test/e2e/key-auth.e2e.test.js
@@ -1,10 +1,11 @@
 const request = require('supertest');
 const cliHelper = require('../common/cli.helper');
 const gwHelper = require('../common/gateway.helper');
+const idGen = require('uuid-base62');
 
 let gatewayProcess = null;
 let gatewayPort, adminPort, configDirectoryPath;
-const username = 'test';
+const username = idGen.v4();
 let keyCred;
 const headerName = 'Authorization';
 const proxyPolicy = {

--- a/test/migrations/credential-username-userid-transform.js
+++ b/test/migrations/credential-username-userid-transform.js
@@ -50,9 +50,7 @@ describe('Migrations', () => {
     });
 
     after(() => {
-      if (tmpFile) {
-        tmpFile.removeCallback();
-      }
+      tmpFile.removeCallback();
       return db.flushdb();
     });
   });


### PR DESCRIPTION
Connects #499 — Extracted from #501 

Review easily with https://github.com/ExpressGateway/express-gateway/pull/507/files?w=1

This PR

1. Will use `uuid.v4()` to generate usernames instead of relying on hardcoded values (this will help tests repeatability)
2. Will make sure that the returned Promise from the migration is a `global.Promise` instance. This is because the `node-migrate` library accepts exclusively that promise, and it will block if that's not happening
3. Will modify a test to create only 2 applications, as the third one is useless and not used

These improvements will help us to migrate to `ioredis`