### PR TITLE
Run tests on a real Redis Instance as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: npm test
+      - run: npm run test-all
 
   "node-8":
     docker:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "exclude": [
       "logo",
       "node_modules",
-      "coverage"
+      "coverage",
+      "test"
     ]
   },
   "types": "./index.d.ts",


### PR DESCRIPTION
Review with: https://github.com/ExpressGateway/express-gateway/pull/521/files?w=1

Connects #499 

The following PR/dragoon/monster will enable CircleCI to execute tests on a real redis instance as well, making sure both memory and real database instance will offer the same experience.