### PR TITLE
Publish only the required files on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,15 @@
     "Serhii Kuts <sergeykuc@gmail.com>",
     "Irfan Baqui <irfan.baqui@gmail.com>",
     "Kevin Swiber <kswiber@gmail.com>",
-    "Al Tsang <agilecto@gmail.com>"
+    "Al Tsang <agilecto@gmail.com>",
+    "Vincenzo Chianese <vincenz.chianese@icloud.com>"
+  ],
+  "files": [
+    "admin/",
+    "bin/",
+    "lib/",
+    "migrations/",
+    "index.d.ts"
   ],
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
This PR will modify the package.json files section — these are the only one taken in
account when npm is publishing the package. By skipping these useless files, we'll be
able to reduce the footprint size and make our eslint/node plugin (even though is not
enabled yet) happy again.

And — add myself as contributor 😈 