### PR TITLE
Remove uuid-base62

### DIFF
--- a/lib/gateway/context.js
+++ b/lib/gateway/context.js
@@ -1,8 +1,8 @@
 const vm = require('vm');
+const uuid = require('uuid/v4');
 
-const uuid62 = require('uuid-base62');
 function EgContextBase () {
-  this.requestID = uuid62.v4();
+  this.requestID = uuid();
 }
 Object.defineProperty(EgContextBase.prototype, 'egContext', {
   get () {

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -1,8 +1,7 @@
 const credentialDao = require('./credential.dao.js');
 const utils = require('../utils');
-const uuidv4 = require('uuid/v4');
+const uuid = require('uuid/v4');
 const config = require('../../config');
-const uuid62 = require('uuid-base62'); // special format for uuid, url friendly base62 encoding
 
 const s = {};
 
@@ -64,8 +63,8 @@ s.insertCredential = function (id, type, credentialDetails) {
           validateNewCredentialProperties(credentialConfig, credentialDetails)
         ]).then(([scopes, credentialProps]) => {
           Object.assign(newCredential, credentialProps);
-          newCredential.keyId = credentialDetails.keyId || uuid62.v4();
-          newCredential.keySecret = credentialDetails.keySecret || uuid62.v4();
+          newCredential.keyId = credentialDetails.keyId || uuid();
+          newCredential.keySecret = credentialDetails.keySecret || uuid();
           newCredential.scopes = JSON.stringify(scopes);
           newCredential.consumerId = id;
 
@@ -259,7 +258,7 @@ function validateAndHashPassword (credentialConfig, credentialDetails) {
   if (!credentialConfig.autoGeneratePassword) {
     throw new Error(`${credentialConfig.passwordKey} is required`); // TODO: replace with validation error
   }
-  const password = uuidv4();
+  const password = uuid();
 
   return utils.saltAndHash(password)
     .then((hash) => ({ hash, password }));

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -64,7 +64,7 @@ s.insertCredential = function (id, type, credentialDetails) {
         ]).then(([scopes, credentialProps]) => {
           Object.assign(newCredential, credentialProps);
           newCredential.keyId = credentialDetails.keyId || uuid();
-          newCredential.keySecret = credentialDetails.keySecret || uuid();
+          newCredential.keySecret = credentialDetails.keySecret || Buffer.from(uuid()).toString('base64');
           newCredential.scopes = JSON.stringify(scopes);
           newCredential.consumerId = id;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,11 +316,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "base-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
-      "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
-    },
     "bcrypt": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
@@ -5134,7 +5129,7 @@
         "arr-flatten": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+          "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
           "dev": true
         },
         "array-unique": {
@@ -5246,7 +5241,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         },
         "balanced-match": {
@@ -5585,7 +5580,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5618,7 +5613,7 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "graceful-fs": {
@@ -5668,7 +5663,7 @@
         "hosted-git-info": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+          "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
           "dev": true
         },
         "imurmurhash": {
@@ -5840,7 +5835,7 @@
         "istanbul-lib-coverage": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
           "dev": true
         },
         "istanbul-lib-hook": {
@@ -6015,7 +6010,7 @@
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6085,7 +6080,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -6115,7 +6110,7 @@
         "normalize-package-data": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -6192,7 +6187,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -6337,7 +6332,7 @@
         "randomatic": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -6411,13 +6406,13 @@
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE=",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+          "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
           "dev": true,
           "requires": {
             "is-equal-shallow": "0.1.3"
@@ -6490,7 +6485,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
           "dev": true
         },
         "set-blocking": {
@@ -6535,7 +6530,7 @@
         "spawn-wrap": {
           "version": "1.3.8",
           "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
-          "integrity": "sha512-Yfkd7Yiwz4RcBPrDWzvhnTzQINBHNqOEhUzOdWZ67Y9b4wzs3Gz6ymuptQmRBpzlpOzroM7jwzmBdRec7JJ0UA==",
+          "integrity": "sha1-+ip5uZDLsLsAGNymdI2INnsZ7DE=",
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -6570,7 +6565,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6633,7 +6628,7 @@
         "test-exclude": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -6702,7 +6697,7 @@
         "which": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -8712,22 +8707,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "uuid-base62": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/uuid-base62/-/uuid-base62-0.1.0.tgz",
-      "integrity": "sha1-oqhTuYvguq7k917kG8PY5aFcD34=",
-      "requires": {
-        "base-x": "1.1.0",
-        "node-uuid": "1.4.8"
-      },
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        }
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "swagger-ui-express": "^2.0.10",
     "util.promisify": "^1.0.0",
     "uuid": "^3.1.0",
-    "uuid-base62": "0.1.0",
     "vhost": "3.0.2",
     "winston": "^2.4.0",
     "yargs": "8.0.2",

--- a/test/cli/apps/activate.test.js
+++ b/test/cli/apps/activate.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:apps:activate';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg apps activate', () => {
   let program, env, user, app1, app2;
@@ -16,7 +16,7 @@ describe('eg apps activate', () => {
     env.prepareHijack();
     return adminHelper.reset()
       .then(() => adminHelper.admin.users.create({
-        username: idGen.v4(),
+        username: idGen(),
         firstname: 'La',
         lastname: 'Deeda'
       }))

--- a/test/cli/apps/create.test.js
+++ b/test/cli/apps/create.test.js
@@ -4,7 +4,7 @@ const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:apps:create';
 const PassThrough = require('stream').PassThrough;
 const util = require('util');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const helpers = require('yeoman-test');
 const { checkOutput } = require('../../common/output-helper');
 
@@ -19,13 +19,13 @@ describe('eg apps create', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
-    });
+      .then(createdUser => {
+        user = createdUser;
+      });
   });
 
   afterEach(() => {

--- a/test/cli/apps/deactivate.test.js
+++ b/test/cli/apps/deactivate.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:apps:deactivate';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg apps deactivate', () => {
   let program, env, user, app1, app2;
@@ -15,7 +15,7 @@ describe('eg apps deactivate', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })

--- a/test/cli/apps/info.test.js
+++ b/test/cli/apps/info.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:apps:info';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg apps info', () => {
   let program, env, user, app;
@@ -13,7 +13,7 @@ describe('eg apps info', () => {
 
   before(() => {
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })

--- a/test/cli/apps/list.test.js
+++ b/test/cli/apps/list.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:apps:list';
 
@@ -16,25 +16,25 @@ describe('eg apps list', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     }).then(user => {
       user1 = user;
       return adminHelper.admin.apps.create(user1.id, {
-        name: idGen.v4(),
+        name: idGen(),
         redirectUri: 'http://localhost:3000/cb'
       });
     }).then(app => {
       app1 = app;
       return adminHelper.admin.apps.create(user1.id, {
-        name: idGen.v4(),
+        name: idGen(),
         redirectUri: 'http://localhost:3000/cb'
       });
     })
-    .then(app => {
-      app2 = app;
-    });
+      .then(app => {
+        app2 = app;
+      });
   });
 
   afterEach(() => {

--- a/test/cli/apps/remove.test.js
+++ b/test/cli/apps/remove.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:apps:remove';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg apps remove', () => {
   let program, env, user, app1, app2;
@@ -19,28 +19,28 @@ describe('eg apps remove', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
+      .then(createdUser => {
+        user = createdUser;
 
-      return adminHelper.admin.apps.create(user.id, {
-        name: 'appy1',
-        redirectUri: 'http://localhost:3000/cb'
+        return adminHelper.admin.apps.create(user.id, {
+          name: 'appy1',
+          redirectUri: 'http://localhost:3000/cb'
+        });
+      })
+      .then(createdApp => {
+        app1 = createdApp;
+        return adminHelper.admin.apps.create(user.id, {
+          name: 'appy2',
+          redirectUri: 'http://localhost:3000/cb'
+        });
+      })
+      .then(createdApp => {
+        app2 = createdApp;
       });
-    })
-    .then(createdApp => {
-      app1 = createdApp;
-      return adminHelper.admin.apps.create(user.id, {
-        name: 'appy2',
-        redirectUri: 'http://localhost:3000/cb'
-      });
-    })
-    .then(createdApp => {
-      app2 = createdApp;
-    });
   });
 
   it('removes an app', done => {

--- a/test/cli/apps/update.test.js
+++ b/test/cli/apps/update.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:apps:update';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const util = require('util');
 const helpers = require('yeoman-test');
 
@@ -21,21 +21,21 @@ describe('eg apps update', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
+      .then(createdUser => {
+        user = createdUser;
 
-      return adminHelper.admin.apps.create(user.id, {
-        name: 'appy1',
-        redirectUri: 'http://localhost:3000/cb'
+        return adminHelper.admin.apps.create(user.id, {
+          name: 'appy1',
+          redirectUri: 'http://localhost:3000/cb'
+        });
+      })
+      .then(createdApp => {
+        app1 = createdApp;
       });
-    })
-    .then(createdApp => {
-      app1 = createdApp;
-    });
   });
   it('updates an app from prompts', done => {
     env.hijack(namespace, generator => {

--- a/test/cli/credential-scopes/add.test.js
+++ b/test/cli/credential-scopes/add.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:credential-scopes:add';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credential:scopes add', () => {
   let program, env, user, cred1, scope1, scope2;
@@ -15,23 +15,23 @@ describe('eg credential:scopes add', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'f',
       lastname: 'l'
     })
-    .then(createdUser => {
-      user = createdUser;
-      return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
-    })
-    .then(createdCred => {
-      cred1 = createdCred;
-      scope1 = idGen.v4();
-      scope2 = idGen.v4();
-      return Promise.all([
-        adminHelper.admin.scopes.create(scope1),
-        adminHelper.admin.scopes.create(scope2)
-      ]);
-    });
+      .then(createdUser => {
+        user = createdUser;
+        return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
+      })
+      .then(createdCred => {
+        cred1 = createdCred;
+        scope1 = idGen();
+        scope2 = idGen();
+        return Promise.all([
+          adminHelper.admin.scopes.create(scope1),
+          adminHelper.admin.scopes.create(scope2)
+        ]);
+      });
   });
 
   afterEach(() => {

--- a/test/cli/credential-scopes/remove.test.js
+++ b/test/cli/credential-scopes/remove.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:credential-scopes:remove';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credential:scopes remove', () => {
   let program, env, user, cred1, scope1, scope2, scope3;
@@ -14,30 +14,30 @@ describe('eg credential:scopes remove', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    scope1 = idGen.v4();
-    scope2 = idGen.v4();
-    scope3 = idGen.v4();
+    scope1 = idGen();
+    scope2 = idGen();
+    scope3 = idGen();
     return Promise.all([
       adminHelper.admin.scopes.create(scope1),
       adminHelper.admin.scopes.create(scope2),
       adminHelper.admin.scopes.create(scope3)
     ]).then(() => {
       return adminHelper.admin.users.create({
-        username: idGen.v4(),
+        username: idGen(),
         firstname: 'f',
         lastname: 'l'
       });
     })
-    .then(createdUser => {
-      user = createdUser;
-      return adminHelper.admin.credentials.create(user.id, 'key-auth', {
-        scopes: [scope1, scope2, scope3]
+      .then(createdUser => {
+        user = createdUser;
+        return adminHelper.admin.credentials.create(user.id, 'key-auth', {
+          scopes: [scope1, scope2, scope3]
+        });
+      })
+      .then(createdCred => {
+        cred1 = createdCred;
+        assert.equal(cred1.scopes.length, 3);
       });
-    })
-    .then(createdCred => {
-      cred1 = createdCred;
-      assert.equal(cred1.scopes.length, 3);
-    });
   });
 
   afterEach(() => {

--- a/test/cli/credential-scopes/set.test.js
+++ b/test/cli/credential-scopes/set.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:credential-scopes:set';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credential:scopes set', () => {
   let program, env, user, cred1, scope1, scope2, scope3;
@@ -14,30 +14,30 @@ describe('eg credential:scopes set', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    scope1 = idGen.v4();
-    scope2 = idGen.v4();
-    scope3 = idGen.v4();
+    scope1 = idGen();
+    scope2 = idGen();
+    scope3 = idGen();
     return Promise.all([
       adminHelper.admin.scopes.create(scope1),
       adminHelper.admin.scopes.create(scope2),
       adminHelper.admin.scopes.create(scope3)
     ]).then(() => {
       return adminHelper.admin.users.create({
-        username: idGen.v4(),
+        username: idGen(),
         firstname: 'f',
         lastname: 'l'
       });
     })
-    .then(createdUser => {
-      user = createdUser;
-      return adminHelper.admin.credentials.create(user.id, 'key-auth', {
-        scopes: [scope3]
+      .then(createdUser => {
+        user = createdUser;
+        return adminHelper.admin.credentials.create(user.id, 'key-auth', {
+          scopes: [scope3]
+        });
+      })
+      .then(createdCred => {
+        cred1 = createdCred;
+        assert.equal(cred1.scopes[0], scope3);
       });
-    })
-    .then(createdCred => {
-      cred1 = createdCred;
-      assert.equal(cred1.scopes[0], scope3);
-    });
   });
 
   afterEach(() => {

--- a/test/cli/credentials/activate.test.js
+++ b/test/cli/credentials/activate.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:credentials:activate';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credentials activate', () => {
   let program, env, user, cred1;
@@ -15,18 +15,18 @@ describe('eg credentials activate', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'f',
       lastname: 'l'
     })
-    .then(createdUser => {
-      user = createdUser;
-      return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
-    })
-    .then(createdCred => {
-      cred1 = createdCred;
-    })
-    .then(() => adminHelper.admin.credentials.deactivate(cred1.keyId, 'key-auth'));
+      .then(createdUser => {
+        user = createdUser;
+        return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
+      })
+      .then(createdCred => {
+        cred1 = createdCred;
+      })
+      .then(() => adminHelper.admin.credentials.deactivate(cred1.keyId, 'key-auth'));
   });
 
   afterEach(() => {

--- a/test/cli/credentials/create.test.js
+++ b/test/cli/credentials/create.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const PassThrough = require('stream').PassThrough;
 const helpers = require('yeoman-test');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:credentials:create';
 
@@ -18,7 +18,7 @@ describe('eg credentials create', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })

--- a/test/cli/credentials/deactivate.test.js
+++ b/test/cli/credentials/deactivate.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:credentials:deactivate';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credentials deactivate', () => {
   let program, env, user, cred1;
@@ -15,17 +15,17 @@ describe('eg credentials deactivate', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'f',
       lastname: 'l'
     })
-    .then(createdUser => {
-      user = createdUser;
-      return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
-    })
-    .then(createdCred => {
-      cred1 = createdCred;
-    });
+      .then(createdUser => {
+        user = createdUser;
+        return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
+      })
+      .then(createdCred => {
+        cred1 = createdCred;
+      });
   });
 
   afterEach(() => {

--- a/test/cli/credentials/info.test.js
+++ b/test/cli/credentials/info.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:credentials:info';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credentials info', () => {
   let program, env, user, cred;
@@ -15,19 +15,19 @@ describe('eg credentials info', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
+      .then(createdUser => {
+        user = createdUser;
 
-      return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
-    })
-    .then(createdCred => {
-      cred = createdCred;
-      return cred;
-    });
+        return adminHelper.admin.credentials.create(user.id, 'key-auth', {});
+      })
+      .then(createdCred => {
+        cred = createdCred;
+        return cred;
+      });
   });
 
   afterEach(() => {

--- a/test/cli/credentials/list.empty.test.js
+++ b/test/cli/credentials/list.empty.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:credentials:list';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg credentials list -c x [no credentials]', () => {
   let program, env, user;
@@ -16,13 +16,13 @@ describe('eg credentials list -c x [no credentials]', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
-    });
+      .then(createdUser => {
+        user = createdUser;
+      });
   });
 
   it('should show friendly message if no credentials', done => {

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const adminHelper = require('../../common/admin-helper')();
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:credentials:list';
@@ -74,7 +74,7 @@ describe('eg credentials list -c ', () => {
           .admin
           .users
           .create({
-            username: idGen.v4(),
+            username: idGen(),
             firstname: 'La',
             lastname: 'Deeda'
           })

--- a/test/cli/scopes/create.test.js
+++ b/test/cli/scopes/create.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:scopes:create';
 
@@ -15,7 +15,7 @@ describe('eg scopes create', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    scopeName = idGen.v4();
+    scopeName = idGen();
   });
 
   afterEach(() => {
@@ -65,11 +65,11 @@ describe('eg scopes create', () => {
 
       generator.once('end', () => {
         return adminHelper.admin.scopes.info(scopeName)
-              .then(res => {
-                assert.equal(res.scope, scopeName);
-                assert.equal(output, res.scope);
-                done();
-              });
+          .then(res => {
+            assert.equal(res.scope, scopeName);
+            assert.equal(output, res.scope);
+            done();
+          });
       });
     });
 

--- a/test/cli/scopes/info.test.js
+++ b/test/cli/scopes/info.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:scopes:info';
 
@@ -15,7 +15,7 @@ describe('eg scopes info', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    scopeName = idGen.v4();
+    scopeName = idGen();
     return adminHelper.admin.scopes.create(scopeName);
   });
 

--- a/test/cli/scopes/list.test.js
+++ b/test/cli/scopes/list.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:scopes:list';
 
@@ -15,8 +15,8 @@ describe('eg scopes list', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    scopeName = idGen.v4();
-    scopeName2 = idGen.v4();
+    scopeName = idGen();
+    scopeName2 = idGen();
     return adminHelper.admin.scopes.create([scopeName, scopeName2]);
   });
 

--- a/test/cli/scopes/remove.test.js
+++ b/test/cli/scopes/remove.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:scopes:remove';
 
@@ -15,10 +15,10 @@ describe('eg scopes remove', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    scopeName = idGen.v4();
-    scopeName2 = idGen.v4();
+    scopeName = idGen();
+    scopeName2 = idGen();
     return adminHelper.admin.scopes.create(scopeName)
-    .then(() => adminHelper.admin.scopes.create(scopeName2));
+      .then(() => adminHelper.admin.scopes.create(scopeName2));
   });
 
   afterEach(() => {

--- a/test/cli/tokens/revoke.test.js
+++ b/test/cli/tokens/revoke.test.js
@@ -4,7 +4,7 @@ const app = require('../../oauth/bootstrap');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:tokens:revoke';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const authService = require('../../../lib/services').auth;
 
 describe('eg tokens revoke', () => {
@@ -18,39 +18,39 @@ describe('eg tokens revoke', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'f',
       lastname: 'l'
     })
-    .then(createdUser => {
-      user = createdUser;
-      return adminHelper.admin.credentials.create(user.username, 'oauth2', {secret: 'test'});
-    })
-    .then(createdCred => {
-      // cred = createdCred;
-      return request(app)
-        .post('/oauth2/token')
-        .set('Authorization', 'basic ' + (Buffer.from(user.username + ':test').toString('base64')))
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .type('form')
-        .send({
-          grant_type: 'password',
-          username: user.username,
-          password: 'test'
-        })
-        .expect(200);
-    })
-    .then(res => {
-      const token = res.body;
-      assert.ok(token);
-      assert.ok(token.access_token);
-      accessToken = token.access_token;
-      assert.equal(token.token_type, 'Bearer');
-      return authService.authenticateToken(accessToken);
-    })
-    .then(res => {
-      assert.equal(res.consumer.username, user.username);
-    });
+      .then(createdUser => {
+        user = createdUser;
+        return adminHelper.admin.credentials.create(user.username, 'oauth2', { secret: 'test' });
+      })
+      .then(createdCred => {
+        // cred = createdCred;
+        return request(app)
+          .post('/oauth2/token')
+          .set('Authorization', 'basic ' + (Buffer.from(user.username + ':test').toString('base64')))
+          .set('content-type', 'application/x-www-form-urlencoded')
+          .type('form')
+          .send({
+            grant_type: 'password',
+            username: user.username,
+            password: 'test'
+          })
+          .expect(200);
+      })
+      .then(res => {
+        const token = res.body;
+        assert.ok(token);
+        assert.ok(token.access_token);
+        accessToken = token.access_token;
+        assert.equal(token.token_type, 'Bearer');
+        return authService.authenticateToken(accessToken);
+      })
+      .then(res => {
+        assert.equal(res.consumer.username, user.username);
+      });
   });
 
   afterEach(() => {

--- a/test/cli/users/activate.test.js
+++ b/test/cli/users/activate.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:users:activate';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg users activate', () => {
   let program, env, userId, userName, userName2;
@@ -14,23 +14,23 @@ describe('eg users activate', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    userName = idGen.v4();
-    userName2 = idGen.v4();
+    userName = idGen();
+    userName2 = idGen();
     return adminHelper.admin.users.create({
       username: userName,
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(user => {
-      userId = user.id;
-      return adminHelper.admin.users.create({
-        username: userName2,
-        firstname: 'La2',
-        lastname: 'Deeda2'
-      });
-    })
-    .then(() => adminHelper.admin.users.deactivate(userName))
-    .then(() => adminHelper.admin.users.deactivate(userName2));
+      .then(user => {
+        userId = user.id;
+        return adminHelper.admin.users.create({
+          username: userName2,
+          firstname: 'La2',
+          lastname: 'Deeda2'
+        });
+      })
+      .then(() => adminHelper.admin.users.deactivate(userName))
+      .then(() => adminHelper.admin.users.deactivate(userName2));
   });
 
   afterEach(() => {
@@ -139,11 +139,11 @@ describe('eg users activate', () => {
 
       generator.once('end', () => {
         return adminHelper.admin.users.info(userName)
-            .then(user => {
-              assert.equal(user.isActive, true);
-              assert.equal(output, userName);
-              done();
-            }).catch(done);
+          .then(user => {
+            assert.equal(user.isActive, true);
+            assert.equal(output, userName);
+            done();
+          }).catch(done);
       });
     });
 

--- a/test/cli/users/create.test.js
+++ b/test/cli/users/create.test.js
@@ -3,7 +3,7 @@ const PassThrough = require('stream').PassThrough;
 const util = require('util');
 const helpers = require('yeoman-test');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:users:create';
 
@@ -18,7 +18,7 @@ describe('eg users create', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    username = idGen.v4();
+    username = idGen();
   });
 
   afterEach(() => {
@@ -50,19 +50,19 @@ describe('eg users create', () => {
       generator.once('end', () => {
         const stdOutUser = JSON.parse(output);
         return adminHelper.admin.users.info(username)
-              .then(user => {
-                assert.equal(user.username, username);
-                assert.equal(user.firstname, 'La');
-                assert.equal(user.lastname, 'Deeda');
+          .then(user => {
+            assert.equal(user.username, username);
+            assert.equal(user.firstname, 'La');
+            assert.equal(user.lastname, 'Deeda');
 
-                assert.equal(text, 'Created ' + user.id);
+            assert.equal(text, 'Created ' + user.id);
 
-                assert.equal(stdOutUser.username, username);
-                assert.equal(stdOutUser.firstname, 'La');
-                assert.equal(stdOutUser.lastname, 'Deeda');
+            assert.equal(stdOutUser.username, username);
+            assert.equal(stdOutUser.firstname, 'La');
+            assert.equal(stdOutUser.lastname, 'Deeda');
 
-                done();
-              }).catch(done);
+            done();
+          }).catch(done);
       });
     });
 
@@ -132,13 +132,13 @@ describe('eg users create', () => {
 
       generator.once('end', () => {
         return adminHelper.admin.users.info(username)
-              .then(user => {
-                assert.equal(user.username, username);
-                assert.equal(user.firstname, 'La');
-                assert.equal(user.lastname, 'Deeda');
-                assert.equal(output, 'Created ' + username);
-                done();
-              }).catch(done);
+          .then(user => {
+            assert.equal(user.username, username);
+            assert.equal(user.firstname, 'La');
+            assert.equal(user.lastname, 'Deeda');
+            assert.equal(output, 'Created ' + username);
+            done();
+          }).catch(done);
       });
     });
 
@@ -160,14 +160,14 @@ describe('eg users create', () => {
 
       generator.once('end', () => {
         return adminHelper.admin.users.info(username)
-              .then(user => {
-                assert.equal(user.username, username);
-                assert.equal(user.firstname, 'La');
-                assert.equal(user.lastname, 'Deeda');
+          .then(user => {
+            assert.equal(user.username, username);
+            assert.equal(user.firstname, 'La');
+            assert.equal(user.lastname, 'Deeda');
 
-                assert.equal(output, user.id);
-                done();
-              });
+            assert.equal(output, user.id);
+            done();
+          });
       });
     });
 

--- a/test/cli/users/deactivate.test.js
+++ b/test/cli/users/deactivate.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const environment = require('../../fixtures/cli/environment');
 const adminHelper = require('../../common/admin-helper')();
 const namespace = 'express-gateway:users:deactivate';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg users deactivate', () => {
   let program, env, userId, username, username2;
@@ -14,8 +14,8 @@ describe('eg users deactivate', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    username = idGen.v4();
-    username2 = idGen.v4();
+    username = idGen();
+    username2 = idGen();
 
     return adminHelper.admin.users.create({
       username: username,
@@ -134,11 +134,11 @@ describe('eg users deactivate', () => {
 
       generator.once('end', () => {
         return adminHelper.admin.users.info(username)
-            .then(user => {
-              assert.equal(user.isActive, false);
-              assert.equal(output, username);
-              done();
-            });
+          .then(user => {
+            assert.equal(user.isActive, false);
+            assert.equal(output, username);
+            done();
+          });
       });
     });
 

--- a/test/cli/users/info.test.js
+++ b/test/cli/users/info.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:users:info';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 describe('eg users info', () => {
   let program, env, userId, username;
@@ -15,16 +15,16 @@ describe('eg users info', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    username = idGen.v4();
+    username = idGen();
 
     return adminHelper.admin.users.create({
       username: username,
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(user => {
-      userId = user.id;
-    });
+      .then(user => {
+        userId = user.id;
+      });
   });
 
   afterEach(() => {

--- a/test/cli/users/list.test.js
+++ b/test/cli/users/list.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const environment = require('../../fixtures/cli/environment');
 const namespace = 'express-gateway:users:list';
 const superagent = require('superagent');
@@ -18,13 +18,13 @@ describe('eg users list', () => {
   beforeEach(() => {
     env.prepareHijack();
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     }).then(user => {
       user1 = user;
       return adminHelper.admin.users.create({
-        username: idGen.v4(),
+        username: idGen(),
         firstname: 'La',
         lastname: 'Deeda'
       });

--- a/test/cli/users/remove.test.js
+++ b/test/cli/users/remove.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const adminHelper = require('../../common/admin-helper')();
 const environment = require('../../fixtures/cli/environment');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const namespace = 'express-gateway:users:remove';
 
 describe('eg users remove', () => {
@@ -19,7 +19,7 @@ describe('eg users remove', () => {
     const promises = [];
     for (let i = 0; i < 5; i++) {
       promises.push(adminHelper.admin.users.create({
-        username: idGen.v4(),
+        username: idGen(),
         firstname: 'La',
         lastname: 'Deeda'
       }));

--- a/test/cli/users/update.test.js
+++ b/test/cli/users/update.test.js
@@ -3,7 +3,7 @@ const util = require('util');
 const helpers = require('yeoman-test');
 const adminHelper = require('../../common/admin-helper')();
 const environment = require('../../fixtures/cli/environment');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const namespace = 'express-gateway:users:update';
 
 describe('eg users update', () => {
@@ -19,13 +19,13 @@ describe('eg users update', () => {
     env.prepareHijack();
 
     return adminHelper.admin.users.create({
-      username: idGen.v4(),
+      username: idGen(),
       firstname: 'La',
       lastname: 'Deeda'
     })
-    .then(createdUser => {
-      user = createdUser;
-    });
+      .then(createdUser => {
+        user = createdUser;
+      });
   });
 
   afterEach(() => {
@@ -52,7 +52,7 @@ describe('eg users update', () => {
         helpers.mockPrompt(generator, {
           firstname: 'FirstName',
           lastname: 'LastName',
-          email: '_',      // can't have empty values,
+          email: '_', // can't have empty values,
           redirectUri: '_' // limitation of yeoman-test.DummyPrompt
         });
       });
@@ -90,7 +90,7 @@ describe('eg users update', () => {
         helpers.mockPrompt(generator, {
           firstname: 'X1',
           lastname: 'L1',
-          email: '_',      // can't have empty values,
+          email: '_', // can't have empty values,
           redirectUri: '_' // limitation of yeoman-test.DummyPrompt
         });
       });

--- a/test/e2e/key-auth.e2e.test.js
+++ b/test/e2e/key-auth.e2e.test.js
@@ -1,11 +1,11 @@
 const request = require('supertest');
 const cliHelper = require('../common/cli.helper');
 const gwHelper = require('../common/gateway.helper');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 
 let gatewayProcess = null;
 let gatewayPort, adminPort, configDirectoryPath;
-const username = idGen.v4();
+const username = idGen();
 let keyCred;
 const headerName = 'Authorization';
 const proxyPolicy = {

--- a/test/migrations/credential-username-userid-transform.js
+++ b/test/migrations/credential-username-userid-transform.js
@@ -1,6 +1,6 @@
 const migrate = require('migrate');
 const tmp = require('tmp');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const db = require('../../lib/db');
 const { assert } = require('chai');
 const userService = require('../../lib/services/consumers/user.service');
@@ -8,7 +8,7 @@ const credentialService = require('../../lib/services/credentials/credential.ser
 
 describe('Migrations', () => {
   describe('Username -> UserID credential transform', () => {
-    const username = idGen.v4();
+    const username = idGen();
     let tmpFile;
     let userId;
     let oldCredential;

--- a/test/policies/keyauth/keyauth.test.js
+++ b/test/policies/keyauth/keyauth.test.js
@@ -1,5 +1,5 @@
 const headerName = 'Authorization';
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const request = require('supertest');
 const should = require('should');
 
@@ -95,7 +95,7 @@ describe('Functional Tests keyAuth Policy', () => {
     return db.flushdb()
       .then(function () {
         const user1 = {
-          username: idGen.v4(),
+          username: idGen(),
           firstname: 't',
           lastname: 't',
           email: 'test@example.com'

--- a/test/policies/oauth/consumer-and-token-headers.test.js
+++ b/test/policies/oauth/consumer-and-token-headers.test.js
@@ -1,4 +1,4 @@
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const session = require('supertest-session');
 const qs = require('querystring');
 const url = require('url');
@@ -95,7 +95,7 @@ describe('Request @headers @proxy downstream @auth @key-auth', () => {
     return db.flushdb()
       .then(function () {
         const user1 = {
-          username: idGen.v4(),
+          username: idGen(),
           firstname: 'test',
           lastname: 'test',
           email: 'test@eg.com'
@@ -106,7 +106,7 @@ describe('Request @headers @proxy downstream @auth @key-auth', () => {
       .then(_user => {
         user = _user;
         const app1 = {
-          name: idGen.v4(),
+          name: idGen(),
           redirectUri: 'https://some.host.com/some/route'
         };
         return applicationService.insert(app1, user.id);

--- a/test/policies/passthrough.test.js
+++ b/test/policies/passthrough.test.js
@@ -1,4 +1,4 @@
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const request = require('supertest');
 
 const services = require('../../lib/services');
@@ -46,13 +46,15 @@ describe('Functional Tests @auth Policies @passthrough', () => {
               action: {
                 passThrough: true
               }
-            }]},
+            }]
+          },
           {
             'basic-auth': [{
               action: {
                 passThrough: true
               }
-            }]},
+            }]
+          },
           {
             'oauth2': [{
               action: {
@@ -69,7 +71,7 @@ describe('Functional Tests @auth Policies @passthrough', () => {
     return db.flushdb()
       .then(function () {
         const user1 = {
-          username: idGen.v4(),
+          username: idGen(),
           firstname: 't',
           lastname: 't',
           email: 'test@example.com'
@@ -90,7 +92,7 @@ describe('Functional Tests @auth Policies @passthrough', () => {
         user = userRes;
         return serverHelper.generateBackendServer();
       })
-      .then(({port}) => {
+      .then(({ port }) => {
         config.gatewayConfig.serviceEndpoints.backend.url += port;
         return helper.setup();
       })

--- a/test/rest-api/api-endpoint.test.js
+++ b/test/rest-api/api-endpoint.test.js
@@ -4,14 +4,14 @@ const Config = require('../../lib/config/config');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const yaml = require('js-yaml');
 
 describe('REST: api endpoints', () => {
   let config;
   beforeEach(() => {
     config = new Config();
-    config.gatewayConfigPath = path.join(os.tmpdir(), idGen.v4() + 'yml');
+    config.gatewayConfigPath = path.join(os.tmpdir(), idGen() + 'yml');
   });
 
   afterEach(() => {
@@ -21,17 +21,17 @@ describe('REST: api endpoints', () => {
   describe('when no api endpoints defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         apiEndpoints: null
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new api endpoint', () => {
       const testEndpoint = {
         host: 'express-gateway.io',
-        customId: idGen.v4()
+        customId: idGen()
       };
       return adminHelper.admin.config.apiEndpoints
         .create('test', testEndpoint)
@@ -47,20 +47,20 @@ describe('REST: api endpoints', () => {
   describe('when api endpoints defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         apiEndpoints: {
-          example: {host: 'example.com'},
-          hello: {host: 'hello.com'}
+          example: { host: 'example.com' },
+          hello: { host: 'hello.com' }
         }
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new api endpoint', () => {
       const testEndpoint = {
         host: 'express-gateway.io',
-        customId: idGen.v4() // NOTE: save operation should allow custom props
+        customId: idGen() // NOTE: save operation should allow custom props
       };
       return adminHelper.admin.config.apiEndpoints
         .create('test', testEndpoint)
@@ -76,7 +76,7 @@ describe('REST: api endpoints', () => {
     it('should update existing endpoint', () => {
       const testEndpoint = {
         host: 'express-gateway.io',
-        customId: idGen.v4()
+        customId: idGen()
       };
       return adminHelper.admin.config.apiEndpoints
         .update('example', testEndpoint)

--- a/test/rest-api/applications.js
+++ b/test/rest-api/applications.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const adminHelper = require('../common/admin-helper')();
 
 describe('REST: Applications', () => {
@@ -14,7 +14,7 @@ describe('REST: Applications', () => {
   afterEach(() => adminHelper.reset());
   after(() => adminHelper.stop());
 
-  const username = idGen.v4();
+  const username = idGen();
 
   describe('Insert two applications with the same name under the same user', () => {
     before(() => adminHelper.admin.users.create({

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -4,14 +4,14 @@ const Config = require('../../lib/config/config');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const yaml = require('js-yaml');
 
 describe('REST: pipelines', () => {
   let config;
   beforeEach(() => {
     config = new Config();
-    config.gatewayConfigPath = path.join(os.tmpdir(), idGen.v4() + 'yml');
+    config.gatewayConfigPath = path.join(os.tmpdir(), idGen() + 'yml');
   });
 
   afterEach(() => {
@@ -21,18 +21,18 @@ describe('REST: pipelines', () => {
   describe('when no pipelines defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         pipelines: null
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
-        policies: [{action: 'proxy'}],
-        customId: idGen.v4() // NOTE: save operation should allow custom props
+        policies: [{ action: 'proxy' }],
+        customId: idGen() // NOTE: save operation should allow custom props
       };
       return adminHelper.admin.config.pipelines
         .create('test', testPipeline)
@@ -49,21 +49,21 @@ describe('REST: pipelines', () => {
   describe('when pipelines defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         pipelines: {
-          example: {apiEndpoints: ['example']},
-          hello: {apiEndpoints: ['hello']}
+          example: { apiEndpoints: ['example'] },
+          hello: { apiEndpoints: ['hello'] }
         }
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
-        customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{action: 'proxy'}]
+        customId: idGen(), // NOTE: save operation should allow custom props
+        policies: [{ action: 'proxy' }]
       };
       return adminHelper.admin.config.pipelines
         .create('test', testPipeline)
@@ -79,8 +79,8 @@ describe('REST: pipelines', () => {
     it('should update existing pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
-        customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{action: 'proxy'}]
+        customId: idGen(), // NOTE: save operation should allow custom props
+        policies: [{ action: 'proxy' }]
       };
       return adminHelper.admin.config.pipelines
         .update('example', testPipeline)

--- a/test/rest-api/policies.test.js
+++ b/test/rest-api/policies.test.js
@@ -4,14 +4,14 @@ const Config = require('../../lib/config/config');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const yaml = require('js-yaml');
 
 describe('REST: policies', () => {
   let config;
   beforeEach(() => {
     config = new Config();
-    config.gatewayConfigPath = path.join(os.tmpdir(), idGen.v4() + 'yml');
+    config.gatewayConfigPath = path.join(os.tmpdir(), idGen() + 'yml');
   });
 
   afterEach(() => {
@@ -21,12 +21,12 @@ describe('REST: policies', () => {
   describe('when no policies defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         policies: null
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should activate new policy', () => {
       return adminHelper.admin.config.policies
@@ -42,12 +42,12 @@ describe('REST: policies', () => {
   describe('when policies defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         policies: ['example', 'hello']
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new api endpoint', () => {
       return adminHelper.admin.config.policies

--- a/test/rest-api/schemas.test.js
+++ b/test/rest-api/schemas.test.js
@@ -5,14 +5,14 @@ const Config = require('../../lib/config/config');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const yaml = require('js-yaml');
 
 describe('REST: schemas', () => {
   let config;
   beforeEach(() => {
     config = new Config();
-    config.gatewayConfigPath = path.join(os.tmpdir(), idGen.v4() + 'yml');
+    config.gatewayConfigPath = path.join(os.tmpdir(), idGen() + 'yml');
   });
 
   afterEach(() => {

--- a/test/rest-api/service-endpoint.test.js
+++ b/test/rest-api/service-endpoint.test.js
@@ -4,14 +4,14 @@ const Config = require('../../lib/config/config');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const idGen = require('uuid-base62');
+const idGen = require('uuid/v4');
 const yaml = require('js-yaml');
 
 describe('REST: service endpoints', () => {
   let config;
   beforeEach(() => {
     config = new Config();
-    config.gatewayConfigPath = path.join(os.tmpdir(), idGen.v4() + 'yml');
+    config.gatewayConfigPath = path.join(os.tmpdir(), idGen() + 'yml');
   });
 
   afterEach(() => {
@@ -21,17 +21,17 @@ describe('REST: service endpoints', () => {
   describe('when no service endpoints defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         serviceEndpoints: null
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new service endpoint', () => {
       const testEndpoint = {
         url: 'express-gateway.io',
-        customId: idGen.v4()
+        customId: idGen()
       };
       return adminHelper.admin.config.serviceEndpoints
         .create('test', testEndpoint)
@@ -47,20 +47,20 @@ describe('REST: service endpoints', () => {
   describe('when service endpoints defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: {port: 0},
+        admin: { port: 0 },
         serviceEndpoints: {
-          example: {url: 'example.com'},
-          hello: {url: 'hello.com'}
+          example: { url: 'example.com' },
+          hello: { url: 'hello.com' }
         }
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
-      return adminHelper.start({config});
+      return adminHelper.start({ config });
     });
     it('should create a new service endpoint', () => {
       const testEndpoint = {
         url: 'express-gateway.io',
-        customId: idGen.v4() // NOTE: save operation should allow custom props
+        customId: idGen() // NOTE: save operation should allow custom props
       };
       return adminHelper.admin.config.serviceEndpoints
         .create('test', testEndpoint)
@@ -76,7 +76,7 @@ describe('REST: service endpoints', () => {
     it('should update existing endpoint', () => {
       const testEndpoint = {
         url: 'express-gateway.io',
-        customId: idGen.v4()
+        customId: idGen()
       };
       return adminHelper.admin.config.serviceEndpoints
         .update('example', testEndpoint)

--- a/test/services/applications.test.js
+++ b/test/services/applications.test.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const uuid = require('uuid');
+const uuid = require('uuid/v4');
 const config = require('../../lib/config');
 const services = require('../../lib/services');
 const applicationService = services.application;
@@ -668,9 +668,9 @@ describe('Application service tests', function () {
 
 function createRandomUserObject () {
   return {
-    username: uuid.v4(),
-    firstname: uuid.v4(),
-    lastname: uuid.v4(),
-    email: uuid.v4()
+    username: uuid(),
+    firstname: uuid(),
+    lastname: uuid(),
+    email: uuid()
   };
 }

--- a/test/services/users.test.js
+++ b/test/services/users.test.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const uuid = require('uuid');
+const uuid = require('uuid/v4');
 const redisConfig = require('../../lib/config').systemConfig.db.redis;
 const services = require('../../lib/services');
 const userService = services.user;
@@ -133,7 +133,7 @@ describe('User service tests', function () {
     });
 
     it('should not get user by invalid userId', function (done) {
-      userService.get(uuid.v4())
+      userService.get(uuid())
         .then(function (user) {
           should.exist(user);
           user.should.eql(false);
@@ -367,9 +367,9 @@ describe('User service tests', function () {
 
 function createRandomUserObject () {
   return {
-    username: uuid.v4(),
-    firstname: uuid.v4(),
-    lastname: uuid.v4(),
-    email: uuid.v4()
+    username: uuid(),
+    firstname: uuid(),
+    lastname: uuid(),
+    email: uuid()
   };
 }


### PR DESCRIPTION
This PR will remove `uuid-base62` package (that's internally using multiple deprecated packages). We can use `uuid/v4` directly or, when really needed, `Buffer.from(uuid()).toString('base64')->NjY1Mzk2MTQtZGU5OC00ZGM1LTg0ZDgtOWRkNjVkYTQ2MzIz`

