### PR TITLE
Fix yet another part for autodeploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,18 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-6
-      - node-8
-      - node-8-real-redis
+      - node-6:
+          filters:
+            tags:
+              only: /v\d+(\.\d+){2}/
+      - node-8:
+          filters:
+            tags:
+              only: /v\d+(\.\d+){2}/
+      - node-8-real-redis:
+          filters:
+            tags:
+              only: /v\d+(\.\d+){2}/
       - deploy:
           filters:
             tags:
@@ -70,3 +79,4 @@ workflows:
           requires:
             - node-8
             - node-6
+            - node-8-real-redis


### PR DESCRIPTION
Today during the deploy phase the trigger for auto publish didn't trigger. 👎. Shame on me.
I searched for the docs one more time and here we are.

The tag dependency must be declared in all the dependent jobs as well
https://discuss.circleci.com/t/builds-for-tags-not-triggering/17681/5