### PR TITLE
Introduce JWT token type

### DIFF
--- a/bin/generators/credentials/create.js
+++ b/bin/generators/credentials/create.js
@@ -160,7 +160,7 @@ module.exports = class extends eg.Generator {
       this.log.ok(`Created ${credential.id || credential.keyId}`);
       this.stdout(JSON.stringify(credential, null, 2));
     } else {
-      if (argv.type === 'key-auth') {
+      if (argv.type === 'key-auth' || argv.type === 'jwt') {
         this.stdout(`${credential.keyId}:${credential.keySecret}`);
       } else if (argv.type === 'basic-auth') {
         this.stdout(`${credential.id}:${credential.password}`);

--- a/bin/generators/gateway/templates/basic/config/models/credentials.js
+++ b/bin/generators/gateway/templates/basic/config/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/bin/generators/gateway/templates/getting-started/config/models/credentials.js
+++ b/bin/generators/gateway/templates/getting-started/config/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/lib/config/models/credentials.js
+++ b/lib/config/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/lib/policies/jwt/extractors.js
+++ b/lib/policies/jwt/extractors.js
@@ -1,0 +1,9 @@
+const passportJWT = require('passport-jwt');
+
+module.exports = {
+  'header': passportJWT.ExtractJwt.fromHeader,
+  'body': passportJWT.ExtractJwt.fromBodyField,
+  'query': passportJWT.ExtractJwt.fromUrlQueryParameter,
+  'authScheme': passportJWT.ExtractJwt.fromAuthHeaderWithScheme,
+  'authBearer': passportJWT.ExtractJwt.fromAuthHeaderAsBearerToken
+};

--- a/lib/policies/jwt/extractors.js
+++ b/lib/policies/jwt/extractors.js
@@ -2,7 +2,6 @@ const passportJWT = require('passport-jwt');
 
 module.exports = {
   'header': passportJWT.ExtractJwt.fromHeader,
-  'body': passportJWT.ExtractJwt.fromBodyField,
   'query': passportJWT.ExtractJwt.fromUrlQueryParameter,
   'authScheme': passportJWT.ExtractJwt.fromAuthHeaderWithScheme,
   'authBearer': passportJWT.ExtractJwt.fromAuthHeaderAsBearerToken

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -19,9 +19,6 @@ module.exports = {
       jwtExtractorField: {
         type: 'string'
       },
-      issuer: {
-        type: 'string'
-      },
       audience: {
         type: 'string'
       }

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -5,10 +5,10 @@ module.exports = {
   schema: {
     type: 'object',
     properties: {
-      secret: {
+      secretOrPubKey: {
         type: 'string'
       },
-      secretFile: {
+      secretOrPubKeyFile: {
         type: 'string'
       },
       jwtExtractor: {
@@ -27,6 +27,6 @@ module.exports = {
       }
     },
     required: ['jwtExtractor'],
-    oneOf: [{ required: ['secret'] }, { required: ['secretFile'] }]
+    oneOf: [{ required: ['secretOrPubKey'] }, { required: ['secretOrPubKeyFile'] }]
   }
 };

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -1,0 +1,32 @@
+const extractors = require('./extractors');
+
+module.exports = {
+  policy: require('./jwt'),
+  schema: {
+    type: 'object',
+    properties: {
+      secret: {
+        type: 'string'
+      },
+      secretFile: {
+        type: 'string'
+      },
+      jwtExtractor: {
+        type: 'string',
+        enum: Object.keys(extractors),
+        default: 'authBearer'
+      },
+      jwtExtractorField: {
+        type: 'string'
+      },
+      issuer: {
+        type: 'string'
+      },
+      audience: {
+        type: 'string'
+      }
+    },
+    required: ['jwtExtractor'],
+    oneOf: [{ required: ['secret'] }, { required: ['secretFile'] }]
+  }
+};

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -21,6 +21,9 @@ module.exports = {
       },
       audience: {
         type: 'string'
+      },
+      issuer: {
+        type: 'string'
       }
     },
     required: ['jwtExtractor'],

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -24,9 +24,13 @@ module.exports = {
       },
       issuer: {
         type: 'string'
+      },
+      checkCredentialExistence: {
+        type: 'boolean',
+        default: true
       }
     },
-    required: ['jwtExtractor'],
+    required: ['jwtExtractor', 'checkCredentialExistence'],
     oneOf: [{ required: ['secretOrPubKey'] }, { required: ['secretOrPubKeyFile'] }]
   }
 };

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -1,1 +1,26 @@
-module.exports = {};
+const fs = require('fs');
+const passport = require('passport');
+const JWTStrategy = require('passport-jwt').Strategy;
+const extractors = require('./extractors');
+
+module.exports = function (params) {
+  const secret = params.secretFile ? fs.readFileSync(params.secretFile) : params.secret;
+
+  passport.use(new JWTStrategy({
+    secretOrKey: secret,
+    jwtFromRequest: extractors[params.jwtExtractor](params.jwtExtractorField),
+    audience: params.audience,
+    issuer: params.issuer
+  }, (jwtPayload, done) => {
+    if (!jwtPayload) {
+      return done(null, false);
+    }
+
+    return done(null, jwtPayload);
+  }));
+
+  return function (req, res, next) {
+    params.session = false;
+    passport.authenticate('jwt', params, params.getCommonAuthCallback(req, res, next))(req, res, next);
+  };
+};

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -11,13 +11,14 @@ module.exports = function (params) {
   passport.use(new JWTStrategy({
     secretOrKey: secret,
     jwtFromRequest: extractor,
-    audience: params.audience
+    audience: params.audience,
+    issuer: params.issuer
   }, (jwtPayload, done) => {
-    if (!jwtPayload || !jwtPayload.iss) {
+    if (!jwtPayload || !jwtPayload.sub) {
       return done(null, false);
     }
 
-    services.credential.getCredential(jwtPayload.iss, 'jwt')
+    services.credential.getCredential(jwtPayload.sub, 'jwt')
       .then(credential => {
         if (!credential || !credential.isActive) {
           return false;

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -11,8 +11,7 @@ module.exports = function (params) {
   passport.use(new JWTStrategy({
     secretOrKey: secret,
     jwtFromRequest: extractor,
-    audience: params.audience,
-    issuer: params.issuer
+    audience: params.audience
   }, (jwtPayload, done) => {
     if (!jwtPayload || !jwtPayload.iss) {
       return done(null, false);

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const passport = require('passport');
 const JWTStrategy = require('passport-jwt').Strategy;
 const extractors = require('./extractors');
-const { credential } = require('../../services');
+const { auth } = require('../../services');
 
 module.exports = function (params) {
   const secret = params.secretFile ? fs.readFileSync(params.secretFile) : params.secret;
@@ -13,21 +13,18 @@ module.exports = function (params) {
     audience: params.audience,
     issuer: params.issuer
   }, (jwtPayload, done) => {
-    // Verify that there's something in the payload.
-
     if (!jwtPayload) {
       return done(null, false);
     }
 
-    // Verify the credential is existing
-    credential.getCredential(jwtPayload.iss, 'jwt')
-      .then((credential) => {
-        if (!credential) {
+    auth.authenticateCredential(jwtPayload.iss, params.secret, 'jwt')
+      .then((consumer) => {
+        if (!consumer) {
           return done(null, false);
         }
 
-        return done(null, jwtPayload);
-      });
+        return done(null, consumer);
+      }).catch(done);
   }));
 
   return function (req, res, next) {

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const passport = require('passport');
 const JWTStrategy = require('passport-jwt').Strategy;
 const extractors = require('./extractors');
+const { credential } = require('../../services');
 
 module.exports = function (params) {
   const secret = params.secretFile ? fs.readFileSync(params.secretFile) : params.secret;
@@ -12,11 +13,21 @@ module.exports = function (params) {
     audience: params.audience,
     issuer: params.issuer
   }, (jwtPayload, done) => {
+    // Verify that there's something in the payload.
+
     if (!jwtPayload) {
       return done(null, false);
     }
 
-    return done(null, jwtPayload);
+    // Verify the credential is existing
+    credential.getCredential(jwtPayload.iss, 'jwt')
+      .then((credential) => {
+        if (!credential) {
+          return done(null, false);
+        }
+
+        return done(null, jwtPayload);
+      });
   }));
 
   return function (req, res, next) {

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -6,10 +6,11 @@ const services = require('../../services');
 
 module.exports = function (params) {
   const secret = params.secretFile ? fs.readFileSync(params.secretFile) : params.secret;
+  const extractor = extractors[params.jwtExtractor](params.jwtExtractorField);
 
   passport.use(new JWTStrategy({
     secretOrKey: secret,
-    jwtFromRequest: extractors[params.jwtExtractor](params.jwtExtractorField),
+    jwtFromRequest: extractor,
     audience: params.audience,
     issuer: params.issuer
   }, (jwtPayload, done) => {

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const passport = require('passport');
 const JWTStrategy = require('passport-jwt').Strategy;
 const extractors = require('./extractors');
-const { auth } = require('../../services');
+const services = require('../../services');
 
 module.exports = function (params) {
   const secret = params.secretFile ? fs.readFileSync(params.secretFile) : params.secret;
@@ -17,7 +17,14 @@ module.exports = function (params) {
       return done(null, false);
     }
 
-    auth.authenticateCredential(jwtPayload.iss, params.secret, 'jwt')
+    services.credential.getCredential(jwtPayload.iss, 'jwt')
+      .then(credential => {
+        if (!credential || !credential.isActive) {
+          return false;
+        }
+        return credential.consumerId;
+      })
+      .then(services.auth.validateConsumer)
       .then((consumer) => {
         if (!consumer) {
           return done(null, false);

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -14,7 +14,7 @@ module.exports = function (params) {
     audience: params.audience,
     issuer: params.issuer
   }, (jwtPayload, done) => {
-    if (!jwtPayload) {
+    if (!jwtPayload || !jwtPayload.iss) {
       return done(null, false);
     }
 

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -5,11 +5,11 @@ const extractors = require('./extractors');
 const services = require('../../services');
 
 module.exports = function (params) {
-  const secret = params.secretFile ? fs.readFileSync(params.secretFile) : params.secret;
+  const secretOrKey = params.secretOrPubKeyFile ? fs.readFileSync(params.secretOrPubKeyFile) : params.secretOrPubKey;
   const extractor = extractors[params.jwtExtractor](params.jwtExtractorField);
 
   passport.use(new JWTStrategy({
-    secretOrKey: secret,
+    secretOrKey,
     jwtFromRequest: extractor,
     audience: params.audience,
     issuer: params.issuer

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -14,7 +14,15 @@ module.exports = function (params) {
     audience: params.audience,
     issuer: params.issuer
   }, (jwtPayload, done) => {
-    if (!jwtPayload || !jwtPayload.sub) {
+    if (!jwtPayload) {
+      return done(null, false);
+    }
+
+    if (!params.checkCredentialExistence) {
+      return done(null, { id: 'anonymous' });
+    }
+
+    if (!jwtPayload.sub) {
       return done(null, false);
     }
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -17,13 +17,13 @@ module.exports = function (params, config) {
   if (!endpoint) {
     throw new Error(
       `service endpoint ${serviceEndpointKey} (referenced in 'proxy' ` +
-        'policy configuration) does not exist');
+      'policy configuration) does not exist');
   }
 
   if (!endpoint.url && !endpoint.urls) {
     throw new Error(
       `service endpoint ${serviceEndpointKey} (referenced in 'proxy' ` +
-        'policy configuration) does not contain a `url` or `urls` property');
+      'policy configuration) does not contain a `url` or `urls` property');
   }
 
   const proxy = httpProxy.createProxyServer({
@@ -56,12 +56,13 @@ module.exports = function (params, config) {
     const targetUrl = balancer.nextTarget();
     proxyOptions.target = Object.assign(proxyOptions.target, targetUrl);
 
-    logger.debug(`proxying to ${targetUrl}, ${req.method} ${req.url}`);
+    logger.debug(`proxying to ${targetUrl.href}, ${req.method} ${req.url}`);
     const intermediateProxySettings = process.env.http_proxy || params.proxyUrl;
     if (intermediateProxySettings) {
       logger.debug(`using intermediate proxy ${intermediateProxySettings}`);
       proxyOptions.agent = new ProxyAgent(intermediateProxySettings);
     }
+
     prepareHeaders(params, proxyOptions, req.egContext);
     proxy.web(req, res, proxyOptions);
   };

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -2,7 +2,8 @@ const Ajv = require('ajv');
 const predefined = require('./predefined');
 
 const ajv = new Ajv({
-  schemas: predefined
+  schemas: predefined,
+  useDefaults: true
 });
 
 const buildKey = (type, name) => `${type}:${name}`;

--- a/lib/services/auth.js
+++ b/lib/services/auth.js
@@ -12,7 +12,7 @@ s.authenticateCredential = function (id, password, type) {
     return Promise.resolve(false);
   }
 
-  if (type === 'key-auth') {
+  if (type === 'key-auth' || type === 'jwt') {
     return credentials.getCredential(id, type, { includePassword: true })
       .then(credential => {
         if (!credential || !credential.isActive || credential.keySecret !== password) {

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -58,7 +58,7 @@ s.insertCredential = function (id, type, credentialDetails) {
       utils.appendCreatedAt(newCredential);
       utils.appendUpdatedAt(newCredential);
 
-      if (type === 'key-auth') { // TODO: if/else is not a good approach, new way TBD
+      if (type === 'key-auth' || type === 'jwt') { // TODO: if/else is not a good approach, new way TBD
         return Promise.all([
           validateNewCredentialScopes(credentialConfig, credentialDetails),
           validateNewCredentialProperties(credentialConfig, credentialDetails)

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,11 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
       "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
     },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+    },
     "bcrypt": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
@@ -439,6 +444,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1275,6 +1285,15 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "requires": {
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "editions": {
@@ -3758,6 +3777,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3943,6 +3967,17 @@
         }
       }
     },
+    "joi": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+      "requires": {
+        "hoek": "2.16.3",
+        "isemail": "1.2.0",
+        "moment": "2.19.2",
+        "topo": "1.1.0"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4006,6 +4041,25 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+      "requires": {
+        "joi": "6.10.1",
+        "jws": "3.1.4",
+        "lodash.once": "4.1.1",
+        "ms": "2.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4056,6 +4110,27 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
+      }
+    },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "requires": {
+        "base64url": "2.0.0",
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "requires": {
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.1"
       }
     },
     "kew": {
@@ -4514,6 +4589,11 @@
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
       "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
     },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
     "lodash.partial": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-4.2.1.tgz",
@@ -4890,6 +4970,11 @@
       "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
       "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
       "dev": true
+    },
+    "moment": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
+      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
     },
     "ms": {
       "version": "2.0.0",
@@ -6948,6 +7033,15 @@
         "passport-strategy": "1.0.0"
       }
     },
+    "passport-jwt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-3.0.1.tgz",
+      "integrity": "sha1-5Pcnba2L0lHUPG/DiIMTC5YycvY=",
+      "requires": {
+        "jsonwebtoken": "7.4.3",
+        "passport-strategy": "1.0.0"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -8288,6 +8382,14 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
+      }
+    },
+    "topo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+      "requires": {
+        "hoek": "2.16.3"
       }
     },
     "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3972,7 +3972,6 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
-        "hoek": "2.16.3",
         "isemail": "1.2.0",
         "moment": "2.19.2",
         "topo": "1.1.0"
@@ -8387,10 +8386,7 @@
     "topo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU="
     },
     "tough-cookie": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "types": "./index.d.ts",
   "dependencies": {
-    "ajv": "^5.3.0",
+    "ajv": "^5.4.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.2",
     "chalk": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Serhii Kuts <sergeykuc@gmail.com>",
     "Irfan Baqui <irfan.baqui@gmail.com>",
     "Kevin Swiber <kswiber@gmail.com>",
-    "Al Tsang <agilecto@gmail.com>"
+    "Al Tsang <agilecto@gmail.com>",
+    "Vincenzo Chianese <vincenz.chianese@icloud.com>"
   ],
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "passport": "^0.4.0",
     "passport-http": "0.3.0",
     "passport-http-bearer": "1.0.1",
+    "passport-jwt": "^3.0.1",
     "passport-local": "1.0.0",
     "passport-oauth2-client-password": "0.1.2",
     "proxy-agent": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "eslint-plugin-standard": "3.0.1",
     "husky": "^0.14.3",
     "istanbul": "0.4.5",
+    "jsonwebtoken": "^7.4.3",
     "lint-staged": "^5.0.0",
     "mocha": "3.3.0",
     "mocha-lcov-reporter": "1.3.0",

--- a/test/config/models/credentials.js
+++ b/test/config/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/test/fixtures/authorization-code/models/credentials.js
+++ b/test/fixtures/authorization-code/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/test/fixtures/hot-reload/models/credentials.js
+++ b/test/fixtures/hot-reload/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/test/fixtures/plugin-installer/config/models/credentials.js
+++ b/test/fixtures/plugin-installer/config/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/test/fixtures/round-robin/models/credentials.js
+++ b/test/fixtures/round-robin/models/credentials.js
@@ -13,6 +13,10 @@ module.exports = {
       scopes: { isRequired: false }
     }
   },
+  'jwt': {
+    properties: {
+    }
+  },
   oauth2: {
     passwordKey: 'secret',
     autoGeneratePassword: true,

--- a/test/migrations/credential-username-userid-transform.js
+++ b/test/migrations/credential-username-userid-transform.js
@@ -15,8 +15,8 @@ describe('Migrations', () => {
     before('I insert some credentials by user name', () => {
       return userService.insert({
         username,
-        firstname: 'Vincenzo',
-        lastname: 'Chianese'
+        firstname: 'Clark',
+        lastname: 'Kent'
       }).then((user) => {
         userId = user.id;
         return credentialService

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -79,8 +79,8 @@ describe('JWT policy', () => {
         return db.flushdb()
           .then(() => userService.insert({
             username: idGen.v4(),
-            firstname: 'Vincenzo',
-            lastname: 'Chianese',
+            firstname: 'Clark',
+            lastname: 'Kent',
             email: 'test@example.com'
           }))
           .then((user) => credentialService.insertCredential(user.id, 'jwt')).then((credential) => { jwtCredential = credential; })

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -95,6 +95,13 @@ describe('JWT policy', () => {
 
       [{
         description: 'should not forward requests without authorization header',
+        signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, 'error'),
+        statusCode: 401
+      }, {
+        description: 'should not forward requests when no issuer is provided',
+        signedJwt: () => jwt.sign({}, jwtSecretTestCase.jwtSecret, jwtSecretTestCase.jwtSignOptions
+        ),
+
         statusCode: 401
       }, {
         description: 'should not forward requests with a unmatching signed JWT',

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -1,4 +1,5 @@
 const idGen = require('uuid-base62');
+const fs = require('fs');
 const request = require('supertest');
 const jwt = require('jsonwebtoken');
 
@@ -12,8 +13,6 @@ const serverHelper = require('../../common/server-helper');
 const config = require('../../../lib/config');
 const testHelper = require('../../common/routing.helper')();
 
-const jwtSecret = 'superSecretString';
-
 const originalGatewayConfig = config.gatewayConfig;
 
 let gateway;
@@ -21,103 +20,137 @@ let backend;
 let jwtCredential;
 
 describe('JWT policy', () => {
-  before('setup', () => {
-    config.gatewayConfig = {
-      http: {
-        port: 0
-      },
-      serviceEndpoints: {
-        backend: {
-          url: 'http://localhost:6057'
-        }
-      },
-      apiEndpoints: {
-        api: {
-          host: '*'
-        }
-      },
-      policies: ['jwt', 'proxy'],
-      pipelines: {
-        pipeline1: {
-          apiEndpoints: ['api'],
-          policies: [{
-            'jwt': {
-              action: {
-                secret: jwtSecret
-              }
+  [{
+    description: 'Secret string',
+    jwtSecret: 'superSecretString',
+    jwtSignOptions: {},
+    actionConfig: {
+      secret: 'superSecretString'
+    }
+  }, {
+    description: 'Secret file',
+    jwtSecret: fs.readFileSync(require.resolve('../../fixtures/certs/client/client.key')),
+    jwtSignOptions: {
+      algorithm: 'RS256'
+    },
+    actionConfig: {
+      secretFile: require.resolve('../../fixtures/certs/client/client.crt')
+    }
+  }].forEach((jwtSecretTestCase) => {
+    describe(jwtSecretTestCase.description, () => {
+      before('setup', () => {
+        config.gatewayConfig = {
+          http: {
+            port: 0
+          },
+          serviceEndpoints: {
+            backend: {
+              url: 'http://localhost:6057'
             }
           },
-          {
-            proxy: [
+          apiEndpoints: {
+            api: {
+              host: '*'
+            }
+          },
+          policies: ['jwt', 'proxy'],
+          pipelines: {
+            pipeline1: {
+              apiEndpoints: ['api'],
+              policies: [{
+                'jwt': {
+                  action: jwtSecretTestCase.actionConfig
+                }
+              },
               {
-                action: { serviceEndpoint: 'backend' }
+                proxy: [
+                  {
+                    action: { serviceEndpoint: 'backend' }
+                  }
+                ]
               }
-            ]
+              ]
+            }
           }
-          ]
-        }
-      }
-    };
+        };
 
-    return db.flushdb()
-      .then(() => userService.insert({
-        username: idGen.v4(),
-        firstname: 'Vincenzo',
-        lastname: 'Chianese',
-        email: 'test@example.com'
-      }))
-      .then((user) => credentialService.insertCredential(user.id, 'jwt')).then((credential) => { jwtCredential = credential; })
-      .then(() => serverHelper.generateBackendServer(6057)).then(({ app }) => { backend = app; })
-      .then(() => testHelper.setup()).then(({ app }) => { gateway = app; });
-  });
+        return db.flushdb()
+          .then(() => userService.insert({
+            username: idGen.v4(),
+            firstname: 'Vincenzo',
+            lastname: 'Chianese',
+            email: 'test@example.com'
+          }))
+          .then((user) => credentialService.insertCredential(user.id, 'jwt')).then((credential) => { jwtCredential = credential; })
+          .then(() => serverHelper.generateBackendServer(6057)).then(({ app }) => { backend = app; })
+          .then(() => testHelper.setup()).then(({ app }) => { gateway = app; });
+      });
 
-  after('cleanup', (done) => {
-    config.gatewayConfig = originalGatewayConfig;
-    backend.close(() => gateway.close(done));
-  });
+      after('cleanup', (done) => {
+        config.gatewayConfig = originalGatewayConfig;
+        backend.close(() => gateway.close(done));
+      });
 
-  [{
-    description: 'should not forward requests without authorization header',
-    statusCode: 401
-  }, {
-    description: 'should not forward requests with a unmatching signed JWT',
-    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, 'error'),
-    statusCode: 401
-  }, {
-    description: 'should not forward requests with a signed JWT but wrong keyID',
-    signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
-    statusCode: 401
-  }, {
-    description: 'should not forward requests with a signed JWT but wrong keyID',
-    signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
-    statusCode: 401
-  }, {
-    description: 'should not forward requests with a signed JWT and correct keyID, but expired token',
-    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId, exp: (Date.now() / 1000) - 1000 }, jwtSecret),
-    statusCode: 401
-  }, {
-    description: 'should not forward requests with a signed JWT and correct keyID, but not valid yet',
-    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId, nbf: (Date.now() / 1000) + 1000 }, jwtSecret),
-    statusCode: 401
-  }, {
-    description: 'should forward requests with a signed JWT and correct keyID',
-    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, jwtSecret),
-    statusCode: 200
-  }, {
-    description: 'should forward requests with a signed JWT and correct keyID, correct nbf and correct expiration',
-    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId, nbf: (Date.now() / 1000) - 1000, exp: (Date.now() / 1000) + 1000 }, jwtSecret),
-    statusCode: 200
-  }].forEach((testCase) => {
-    it(testCase.description, () => {
-      const req = request(gateway)
-        .get('/')
-        .expect(testCase.statusCode);
+      [{
+        description: 'should not forward requests without authorization header',
+        statusCode: 401
+      }, {
+        description: 'should not forward requests with a unmatching signed JWT',
+        signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, 'error'),
+        statusCode: 401
+      }, {
+        description: 'should not forward requests with a signed JWT but wrong keyID',
+        signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
+        statusCode: 401
+      }, {
+        description: 'should not forward requests with a signed JWT but wrong keyID',
+        signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
+        statusCode: 401
+      }, {
+        description: 'should not forward requests with a signed JWT and correct keyID, but expired token',
+        signedJwt: () => jwt.sign(
+          { iss: jwtCredential.keyId, exp: (Date.now() / 1000) - 1000 },
+          jwtSecretTestCase.jwtSecret,
+          jwtSecretTestCase.jwtSignOptions
+        ),
+        statusCode: 401
+      }, {
+        description: 'should not forward requests with a signed JWT and correct keyID, but not valid yet',
+        signedJwt: () => jwt.sign(
+          { iss: jwtCredential.keyId, nbf: (Date.now() / 1000) + 1000 },
+          jwtSecretTestCase.jwtSecret,
+          jwtSecretTestCase.jwtSignOptions
+        ),
+        statusCode: 401
+      }, {
+        description: 'should forward requests with a signed JWT and correct keyID',
+        signedJwt: () => jwt.sign(
+          { iss: jwtCredential.keyId },
+          jwtSecretTestCase.jwtSecret,
+          jwtSecretTestCase.jwtSignOptions
+        ),
+        statusCode: 200
+      }, {
+        description: 'should forward requests with a signed JWT and correct keyID, correct nbf and correct expiration',
+        signedJwt: () => jwt.sign(
+          { iss: jwtCredential.keyId, nbf: (Date.now() / 1000) - 1000, exp: (Date.now() / 1000) + 1000 },
+          jwtSecretTestCase.jwtSecret,
+          jwtSecretTestCase.jwtSignOptions
+        ),
+        statusCode: 200
+      }].forEach((testCase) => {
+        it(testCase.description, () => {
+          const req = request(gateway)
+            .get('/')
+            .expect(testCase.statusCode);
 
-      if (testCase.signedJwt) {
-        return req.set('Authorization', `Bearer ${testCase.signedJwt()}`);
-      }
+          if (testCase.signedJwt) {
+            return req.set('Authorization', `Bearer ${testCase.signedJwt()}`);
+          }
 
-      return req;
+          return req;
+        });
+      });
     });
   });
 });

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -25,7 +25,7 @@ describe('JWT policy', () => {
     jwtSecret: 'superSecretString',
     jwtSignOptions: {},
     actionConfig: {
-      secret: 'superSecretString'
+      secretOrPubKey: 'superSecretString'
     }
   }, {
     description: 'Secret file',
@@ -34,7 +34,7 @@ describe('JWT policy', () => {
       algorithm: 'RS256'
     },
     actionConfig: {
-      secretFile: require.resolve('../../fixtures/certs/client/client.crt'),
+      secretOrPubKeyFile: require.resolve('../../fixtures/certs/client/client.crt'),
       jwtExtractor: 'query',
       jwtExtractorField: 'jwtKey'
     }

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -34,7 +34,9 @@ describe('JWT policy', () => {
       algorithm: 'RS256'
     },
     actionConfig: {
-      secretFile: require.resolve('../../fixtures/certs/client/client.crt')
+      secretFile: require.resolve('../../fixtures/certs/client/client.crt'),
+      jwtExtractor: 'query',
+      jwtExtractorField: 'jwtKey'
     }
   }].forEach((jwtSecretTestCase) => {
     describe(jwtSecretTestCase.description, () => {
@@ -145,7 +147,13 @@ describe('JWT policy', () => {
             .expect(testCase.statusCode);
 
           if (testCase.signedJwt) {
-            return req.set('Authorization', `Bearer ${testCase.signedJwt()}`);
+            if (jwtSecretTestCase.actionConfig.jwtExtractor === 'query') {
+              const query = {};
+              query[jwtSecretTestCase.actionConfig.jwtExtractorField] = testCase.signedJwt();
+              return req.query(query);
+            } else {
+              return req.set('Authorization', `Bearer ${testCase.signedJwt()}`);
+            }
           }
 
           return req;

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -1,0 +1,123 @@
+const idGen = require('uuid-base62');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const db = require('../../../lib/db');
+
+const services = require('../../../lib/services');
+const credentialService = services.credential;
+const userService = services.user;
+
+const serverHelper = require('../../common/server-helper');
+const config = require('../../../lib/config');
+const testHelper = require('../../common/routing.helper')();
+
+const jwtSecret = 'superSecretString';
+
+const originalGatewayConfig = config.gatewayConfig;
+
+let gateway;
+let backend;
+let jwtCredential;
+
+describe('JWT policy', () => {
+  before('setup', () => {
+    config.gatewayConfig = {
+      http: {
+        port: 0
+      },
+      serviceEndpoints: {
+        backend: {
+          url: 'http://localhost:6057'
+        }
+      },
+      apiEndpoints: {
+        api: {
+          host: '*'
+        }
+      },
+      policies: ['jwt', 'proxy'],
+      pipelines: {
+        pipeline1: {
+          apiEndpoints: ['api'],
+          policies: [{
+            'jwt': {
+              action: {
+                secret: jwtSecret
+              }
+            }
+          },
+          {
+            proxy: [
+              {
+                action: { serviceEndpoint: 'backend' }
+              }
+            ]
+          }
+          ]
+        }
+      }
+    };
+
+    return db.flushdb()
+      .then(() => userService.insert({
+        username: idGen.v4(),
+        firstname: 'Vincenzo',
+        lastname: 'Chianese',
+        email: 'test@example.com'
+      }))
+      .then((user) => credentialService.insertCredential(user.id, 'jwt')).then((credential) => { jwtCredential = credential; })
+      .then(() => serverHelper.generateBackendServer(6057)).then(({ app }) => { backend = app; })
+      .then(() => testHelper.setup()).then(({ app }) => { gateway = app; });
+  });
+
+  after('cleanup', (done) => {
+    config.gatewayConfig = originalGatewayConfig;
+    backend.close(() => gateway.close(done));
+  });
+
+  [{
+    description: 'should not forward requests without authorization header',
+    statusCode: 401
+  }, {
+    description: 'should not forward requests with a unmatching signed JWT',
+    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, 'error'),
+    statusCode: 401
+  }, {
+    description: 'should not forward requests with a signed JWT but wrong keyID',
+    signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
+    statusCode: 401
+  }, {
+    description: 'should not forward requests with a signed JWT but wrong keyID',
+    signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
+    statusCode: 401
+  }, {
+    description: 'should not forward requests with a signed JWT and correct keyID, but expired token',
+    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId, exp: (Date.now() / 1000) - 1000 }, jwtSecret),
+    statusCode: 401
+  }, {
+    description: 'should not forward requests with a signed JWT and correct keyID, but not valid yet',
+    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId, nbf: (Date.now() / 1000) + 1000 }, jwtSecret),
+    statusCode: 401
+  }, {
+    description: 'should forward requests with a signed JWT and correct keyID',
+    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, jwtSecret),
+    statusCode: 200
+  }, {
+    description: 'should forward requests with a signed JWT and correct keyID, correct nbf and correct expiration',
+    signedJwt: () => jwt.sign({ iss: jwtCredential.keyId, nbf: (Date.now() / 1000) - 1000, exp: (Date.now() / 1000) + 1000 }, jwtSecret),
+    statusCode: 200
+  }].forEach((testCase) => {
+    it(testCase.description, () => {
+      const req = request(gateway)
+        .get('/')
+        .expect(testCase.statusCode);
+
+      if (testCase.signedJwt) {
+        return req.set('Authorization', `Bearer ${testCase.signedJwt()}`);
+      }
+
+      return req;
+    });
+  });
+});

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -95,7 +95,7 @@ describe('JWT policy', () => {
 
       [{
         description: 'should not forward requests without authorization header',
-        signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, 'error'),
+        signedJwt: () => jwt.sign({ sub: jwtCredential.keyId }, 'error'),
         statusCode: 401
       }, {
         description: 'should not forward requests when no issuer is provided',
@@ -105,20 +105,20 @@ describe('JWT policy', () => {
         statusCode: 401
       }, {
         description: 'should not forward requests with a unmatching signed JWT',
-        signedJwt: () => jwt.sign({ iss: jwtCredential.keyId }, 'error'),
+        signedJwt: () => jwt.sign({ sub: jwtCredential.keyId }, 'error'),
         statusCode: 401
       }, {
         description: 'should not forward requests with a signed JWT but wrong keyID',
-        signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
+        signedJwt: () => jwt.sign({ sub: 'I do not know' }, 'error'),
         statusCode: 401
       }, {
         description: 'should not forward requests with a signed JWT but wrong keyID',
-        signedJwt: () => jwt.sign({ iss: 'I do not know' }, 'error'),
+        signedJwt: () => jwt.sign({ sub: 'I do not know' }, 'error'),
         statusCode: 401
       }, {
         description: 'should not forward requests with a signed JWT and correct keyID, but expired token',
         signedJwt: () => jwt.sign(
-          { iss: jwtCredential.keyId, exp: (Date.now() / 1000) - 1000 },
+          { sub: jwtCredential.keyId, exp: (Date.now() / 1000) - 1000 },
           jwtSecretTestCase.jwtSecret,
           jwtSecretTestCase.jwtSignOptions
         ),
@@ -126,7 +126,7 @@ describe('JWT policy', () => {
       }, {
         description: 'should not forward requests with a signed JWT and correct keyID, but not valid yet',
         signedJwt: () => jwt.sign(
-          { iss: jwtCredential.keyId, nbf: (Date.now() / 1000) + 1000 },
+          { sub: jwtCredential.keyId, nbf: (Date.now() / 1000) + 1000 },
           jwtSecretTestCase.jwtSecret,
           jwtSecretTestCase.jwtSignOptions
         ),
@@ -134,7 +134,7 @@ describe('JWT policy', () => {
       }, {
         description: 'should forward requests with a signed JWT and correct keyID',
         signedJwt: () => jwt.sign(
-          { iss: jwtCredential.keyId },
+          { sub: jwtCredential.keyId },
           jwtSecretTestCase.jwtSecret,
           jwtSecretTestCase.jwtSignOptions
         ),
@@ -142,7 +142,7 @@ describe('JWT policy', () => {
       }, {
         description: 'should forward requests with a signed JWT and correct keyID, correct nbf and correct expiration',
         signedJwt: () => jwt.sign(
-          { iss: jwtCredential.keyId, nbf: (Date.now() / 1000) - 1000, exp: (Date.now() / 1000) + 1000 },
+          { sub: jwtCredential.keyId, nbf: (Date.now() / 1000) - 1000, exp: (Date.now() / 1000) + 1000 },
           jwtSecretTestCase.jwtSecret,
           jwtSecretTestCase.jwtSignOptions
         ),


### PR DESCRIPTION
Connects #419 
Closes #419 

The following PR will introduce a JWT verification policy to the gateway.
People will be able to protect their API and check for a token verification strategy with a secret (HS256) or with a certificate (RS256).

### Notes

- I figured out while implementing the thing that we have a lot of model copies spread around the repository. https://github.com/ExpressGateway/express-gateway/pull/555/commits/ff658ab78fe6bfb2b9d801a5bbd4094e99f58415. As all of these are basically equal, if you guys are ok I'd delete those and make sure they all refer to the same file. I created #556 to track this eventually. @DrMegavolt 

- I tried to write a comprensive test suite. It's testing the whole part with secrets and certificates, checking that the issuer is correct, expiration and not before are checked correctly and so on and so forth. You'll decide if it's enough or not.

- Given that `key-auth` and `jwt` are working almost in the same way (regarding the credential creation/modification and deletion) I've added another condition to the `if` branches where appropriate. We all agree that's not optimal, but that'll do for now, I guess.

- What should be the name of the policy? `jwt`? `jwt-auth`?`jwt-verify`? @altsang @kevinswiber 