### PR TITLE
DRY Config class and disable initial discovery event

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -38,9 +38,17 @@ class Config {
       }
     }
     log.debug(`${baseProp}Path: `, configPath);
-  }
+  };
+
+  reloadConfigFile (name, watchEvent) {
+    const type = name === this.systemConfig ? 'system' : 'gateway';
+    log.info(`${watchEvent} event on ${name} file. Reloading config file.`);
+    type === 'system' ? this.loadSystemConfig() : this.loadGatewayConfig();
+    eventBus.emit('hot-reload', { type, config: this });
+  };
 
   loadSystemConfig () { this.loadConfig({ baseName: 'system.config', baseProp: 'systemConfig' }); }
+
   loadGatewayConfig () { this.loadConfig({ baseName: 'gateway.config', baseProp: 'gatewayConfig' }); }
 
   loadModels () {
@@ -51,18 +59,8 @@ class Config {
   }
 
   watch () {
-    const watchEvents = ['add', 'change'];
-
     this.watcher = chokidar.watch([this.systemConfigPath, this.gatewayConfigPath], { awaitWriteFinish: true, ignoreInitial: true });
-
-    watchEvents.forEach(watchEvent => {
-      this.watcher.on(watchEvent, name => {
-        const type = name === this.systemConfig ? 'system' : 'gateway';
-        log.info(`${watchEvent} event on ${name} file. Reloading config file.`);
-        type === 'system' ? this.loadSystemConfig() : this.loadGatewayConfig();
-        eventBus.emit('hot-reload', { type, config: this });
-      });
-    });
+    ['add', 'change'].forEach(event => this.watcher.on(event, (name) => this.reloadConfigFile(name, event)));
   }
 
   updateGatewayConfig (modifier) {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -5,11 +5,11 @@ const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const YAWN = require('yawn-yaml/cjs');
 const path = require('path');
-const log = require('../logger').config;
 const chokidar = require('chokidar');
 const glob = require('glob');
 const yamlOrJson = require('js-yaml');
 const eventBus = require('../eventBus');
+const log = require('../logger').config;
 
 class Config {
   constructor () {
@@ -59,7 +59,8 @@ class Config {
   }
 
   watch () {
-    this.watcher = chokidar.watch([this.systemConfigPath, this.gatewayConfigPath], { awaitWriteFinish: true, ignoreInitial: true });
+    const watchOptions = { awaitWriteFinish: true, ignoreInitial: true };
+    this.watcher = chokidar.watch([this.systemConfigPath, this.gatewayConfigPath], watchOptions);
     ['add', 'change'].forEach(event => this.watcher.on(event, (name) => this.reloadConfigFile(name, event)));
   }
 

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
 require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
+const fs = require('fs');
 const util = require('util');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
@@ -10,6 +10,7 @@ const chokidar = require('chokidar');
 const glob = require('glob');
 const yamlOrJson = require('js-yaml');
 const eventBus = require('../eventBus');
+
 class Config {
   constructor () {
     this.gatewayConfig = null;
@@ -25,42 +26,27 @@ class Config {
     };
   }
 
-  loadSystemConfig () {
-    let systemConfigPath = this.systemConfigPath || path.join(process.env.EG_CONFIG_DIR, 'system.config.yml');
+  loadConfig ({ baseName, baseProp }) {
+    let configPath = this[`${baseProp}Path`] || path.join(process.env.EG_CONFIG_DIR, `${baseName}.yml`);
     try {
-      this.systemConfig = yamlOrJson.load(fs.readFileSync(systemConfigPath));
-      this.systemConfigPath = systemConfigPath;
+      this[baseProp] = yamlOrJson.load(fs.readFileSync(configPath));
+      this[`${baseProp}Path`] = configPath;
     } catch (err) {
       try {
-        systemConfigPath = path.join(process.env.EG_CONFIG_DIR, 'system.config.json');
-        this.systemConfig = yamlOrJson.load(fs.readFileSync(systemConfigPath));
-        this.systemConfigPath = systemConfigPath;
+        configPath = path.join(process.env.EG_CONFIG_DIR, `${baseName}.json`);
+        this[baseProp] = yamlOrJson.load(fs.readFileSync(configPath));
+        this.configPath = configPath;
       } catch (err) {
         log.error(`failed to (re)load system config: ${err}`);
         throw (err);
       }
     }
-    log.debug('systemConfigPath: ', systemConfigPath);
+    log.debug(`${baseProp}Path: `, configPath);
   }
 
-  loadGatewayConfig () {
-    let gatewayConfigPath = this.gatewayConfigPath || path.join(process.env.EG_CONFIG_DIR, 'gateway.config.yml');
+  loadSystemConfig () { this.loadConfig({ baseName: 'system.config', baseProp: 'systemConfig' }); }
 
-    try {
-      this.gatewayConfig = yamlOrJson.load(fs.readFileSync(gatewayConfigPath));
-      this.gatewayConfigPath = gatewayConfigPath;
-    } catch (err) {
-      try {
-        gatewayConfigPath = path.join(process.env.EG_CONFIG_DIR, 'gateway.config.json');
-        this.gatewayConfig = yamlOrJson.load(fs.readFileSync(gatewayConfigPath));
-        this.gatewayConfigPath = gatewayConfigPath;
-      } catch (err) {
-        log.error(`failed to (re)load gateway config: ${err}`);
-        throw (err);
-      }
-    }
-    log.debug('gatewayConfigPath: ', gatewayConfigPath);
-  }
+  loadGatewayConfig () { this.loadConfig({ baseName: 'gateway.config', baseProp: 'gatewayConfig' }); }
 
   loadModels () {
     glob.sync(path.resolve(process.env.EG_CONFIG_DIR, 'models', '*.js')).forEach(module => {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -19,11 +19,7 @@ class Config {
     this.systemConfigPath = null;
 
     this.models = {};
-
-    this.watchers = {
-      system: null,
-      gateway: null
-    };
+    this.watcher = null;
   }
 
   loadConfig ({ baseName, baseProp }) {
@@ -57,32 +53,16 @@ class Config {
   watch () {
     const watchEvents = ['add', 'change'];
 
-    const watchOptions = {
-      awaitWriteFinish: true,
-      ignoreInitial: true
-    };
-
-    const systemWatcher = chokidar.watch(this.systemConfigPath, watchOptions);
-    const gatewayWatcher = chokidar.watch(this.gatewayConfigPath, watchOptions);
+    this.watcher = chokidar.watch([this.systemConfigPath, this.gatewayConfigPath], { awaitWriteFinish: true });
 
     watchEvents.forEach(watchEvent => {
-      systemWatcher.on(watchEvent, name => {
-        log.info(`${watchEvent} event on ${name} file. Reloading system config ` +
-          `file from ${this.systemConfigPath}`);
-        this.loadSystemConfig();
-        eventBus.emit('hot-reload', { type: 'system', config: this });
-      });
-
-      gatewayWatcher.on(watchEvent, name => {
-        log.info(`${watchEvent} event on ${name} file. Reloading gateway config ` +
-          `file from ${this.gatewayConfigPath}`);
-        this.loadGatewayConfig();
-        eventBus.emit('hot-reload', { type: 'gateway', config: this });
+      this.watcher.on(watchEvent, name => {
+        const type = name === this.systemConfig ? 'system' : 'gateway';
+        log.info(`${watchEvent} event on ${name} file. Reloading config file.`);
+        type === 'system' ? this.loadSystemConfig() : this.loadGatewayConfig();
+        eventBus.emit('hot-reload', { type, config: this });
       });
     });
-
-    this.watchers.system = systemWatcher;
-    this.watchers.gateway = gatewayWatcher;
   }
 
   updateGatewayConfig (modifier) {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -45,7 +45,6 @@ class Config {
   }
 
   loadSystemConfig () { this.loadConfig({ baseName: 'system.config', baseProp: 'systemConfig' }); }
-
   loadGatewayConfig () { this.loadConfig({ baseName: 'gateway.config', baseProp: 'gatewayConfig' }); }
 
   loadModels () {
@@ -84,14 +83,6 @@ class Config {
 
     this.watchers.system = systemWatcher;
     this.watchers.gateway = gatewayWatcher;
-
-    systemWatcher.on('ready', () => {
-      systemWatcher.isReady = true;
-    });
-
-    gatewayWatcher.on('ready', () => {
-      gatewayWatcher.isReady = true;
-    });
   }
 
   updateGatewayConfig (modifier) {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -53,7 +53,7 @@ class Config {
   watch () {
     const watchEvents = ['add', 'change'];
 
-    this.watcher = chokidar.watch([this.systemConfigPath, this.gatewayConfigPath], { awaitWriteFinish: true });
+    this.watcher = chokidar.watch([this.systemConfigPath, this.gatewayConfigPath], { awaitWriteFinish: true, ignoreInitial: true });
 
     watchEvents.forEach(watchEvent => {
       this.watcher.on(watchEvent, name => {


### PR DESCRIPTION
Connect #547 
Closes #547 

This pull request will refactor a bit the `Config` class. 

1. It will extract a generalized method for loading config files, as the code is the same between the two functions.

2. It will tell `chokidar` to avoid the initial discovery event for `add`. This was the cause behind #547 

3. It will use a single watcher for both files instead of instantiating two of them

There's definitely still room for improvement, but this should be hopefully a good start.