### PR TITLE
Password exchange should check for basic-auth credentials

### DIFF
--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -138,7 +138,7 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
     .then(consumer => {
       if (!consumer) return done(null, false);
 
-      return authService.authenticateCredential(username, password, 'oauth2')
+      return authService.authenticateCredential(username, password, 'basic-auth')
         .then(user => {
           let scopeAuthorizationPromise;
 

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -70,8 +70,10 @@ describe('Functional Test Client Password grant', function () {
 
                 credentialService.insertScopes('someScope')
                   .then(() => {
-                    Promise.all([credentialService.insertCredential(fromDbUser1.id, 'oauth2', { secret: 'user-secret' }),
-                      credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })])
+                    Promise.all([
+                      credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
+                      credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
+                    ])
                       .then(([userRes, appRes]) => {
                         should.exist(userRes);
                         should.exist(appRes);
@@ -83,7 +85,7 @@ describe('Functional Test Client Password grant', function () {
       })
       .catch(function (err) {
         should.not.exist(err);
-        done();
+        done(err);
       });
   });
 


### PR DESCRIPTION
I discovered what I think it might be a bug in our password flow while I was writing tests for #567.

According to the specs and to multiple source I checked out around, the `password` flow is meant to be used when you totally trust your client and use it to forward **user's** id and password directly to the auth server, without having to make the whole flow and login/consent screen (that is usually used for untrusted clients).

![](https://image.slidesharecdn.com/gauravroy-stateless-auth-using-oauth-and-jwt-170301155914/95/stateless-auth-using-oauth2-jwt-44-638.jpg?cb=1488384055)

[Source](https://www.slideshare.net/gauravroy/stateless-auth-using-oauth2-jwt)

On the other hand, according to the code, when the Gateway has to validate an userId/password pair is looking for an `oauth2` credential; that is not where the current user's credentials are stored.

They're a `basic-auth` credential type. In the current state, the gateway is instead looking where we store the client ID and secret that is used in to recognize the client executing oAuth2 flow.

This will therefore make any attempt to login fail.

I'm not sure if am correct — could you guys have a look here and confirm, eventually?

Connect #558