### PR TITLE
JSON Schema cleaning up

### DIFF
--- a/admin/config/schemas.js
+++ b/admin/config/schemas.js
@@ -1,14 +1,13 @@
 module.exports = function (client) {
   const baseUrl = 'schemas/';
   return {
-    list (type = '', name = '') {
+    list (param = '') {
       let url = baseUrl;
-      if (type) {
-        url += `/${type}`;
+
+      if (param) {
+        url += encodeURIComponent(param);
       }
-      if (name) {
-        url += `/${name}`;
-      }
+
       return client
         .get(url)
         .then(res => res.body);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import express = require("express");
 import { EventEmitter } from "events";
-import { JSONSchema4 } from "json-schema";
+import { JSONSchema6 } from "json-schema";
 
 declare global {
   namespace Express {
@@ -13,13 +13,13 @@ declare global {
     interface Policy {
       name: string,
       policy(actionParams): express.RequestHandler,
-      schema?: JSONSchema4
+      schema?: JSONSchema6
     }
 
     interface Condition {
       name: string,
       handler(req: express.Request, conditionConfig): boolean,
-      schema?: JSONSchema4
+      schema?: JSONSchema6
     }
 
     interface PluginContext {
@@ -35,7 +35,7 @@ declare global {
       version?: string,
       policies?: Array<string>,
       init(context: PluginContext): void,
-      schema?: JSONSchema4
+      schema?: JSONSchema6
     }
   }
 }

--- a/lib/conditions/index.js
+++ b/lib/conditions/index.js
@@ -13,8 +13,8 @@ function register ({ name, handler, schema }) {
       return handler(req, config);
     }
 
-    logger.warn(`warning: condition ${name} config validation failed`, validationResult.error);
-    return null;
+    logger.error(`Condition ${name} config validation failed`, validationResult.error);
+    throw new Error(`Condition ${name} config validation failed`);
   };
 }
 

--- a/lib/conditions/index.js
+++ b/lib/conditions/index.js
@@ -23,7 +23,7 @@ function init () {
 
   // extending express.request
   express.request.matchEGCondition = function (conditionConfig) {
-    logger.debug('matchEGCondition for %o', conditionConfig);
+    logger.debug('matchEGCondition for', conditionConfig);
     const func = conditions[conditionConfig.name];
     if (!func) {
       logger.warn(`Condition not found for ${conditionConfig.name}`);

--- a/lib/conditions/index.js
+++ b/lib/conditions/index.js
@@ -26,7 +26,7 @@ function init () {
     logger.debug('matchEGCondition for %o', conditionConfig);
     const func = conditions[conditionConfig.name];
     if (!func) {
-      logger.debug(`warning: condition not found for ${conditionConfig.name}`);
+      logger.warn(`Condition not found for ${conditionConfig.name}`);
       return null;
     }
 

--- a/lib/conditions/predefined.js
+++ b/lib/conditions/predefined.js
@@ -4,23 +4,27 @@ module.exports = [
   {
     name: 'always',
     handler: () => true,
-    schema: {}
+    schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/always.json'
+    }
   }, {
     // Not sure if anyone would ever use this in real life, but it is a
     // "legitimate" condition, and is useful during tests.
     name: 'never',
     handler: () => false,
-    schema: {}
+    schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/never.json'
+    }
   }, {
     name: 'allOf',
     handler: (req, actionConfig) => actionConfig.conditions.every(subItem => req.matchEGCondition(subItem)),
     schema: {
-      $id: 'http://express-gateway.io/schemas/allOf.json',
+      $id: 'http://express-gateway.io/schemas/conditions/allOf.json',
       type: 'object',
       properties: {
         conditions: {
           type: 'array',
-          items: { $ref: 'defs.json#/definitions/condition' }
+          items: { $ref: 'base.json' }
         }
       },
       required: ['conditions']
@@ -29,12 +33,12 @@ module.exports = [
     name: 'oneOf',
     handler: (req, actionConfig) => actionConfig.conditions.some(subItem => req.matchEGCondition(subItem)),
     schema: {
-      $id: 'http://express-gateway.io/schemas/oneOf.json',
+      $id: 'http://express-gateway.io/schemas/conditions/oneOf.json',
       type: 'object',
       properties: {
         conditions: {
           type: 'array',
-          items: { $ref: 'defs.json#/definitions/condition' }
+          items: { $ref: 'base.json' }
         }
       },
       required: ['conditions']
@@ -43,10 +47,10 @@ module.exports = [
     name: 'not',
     handler: (req, actionConfig) => !req.matchEGCondition(actionConfig.condition),
     schema: {
-      $id: 'http://express-gateway.io/schemas/not.json',
+      $id: 'http://express-gateway.io/schemas/conditions/not.json',
       type: 'object',
       properties: {
-        condition: { $ref: 'defs.json#/definitions/condition' }
+        condition: { $ref: 'base.json' }
       },
       required: ['condition']
     }
@@ -54,6 +58,7 @@ module.exports = [
     name: 'pathMatch',
     handler: (req, actionConfig) => req.url.match(new RegExp(actionConfig.pattern)) !== null,
     schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/pathMatch.json',
       type: 'object',
       properties: {
         pattern: {
@@ -66,6 +71,7 @@ module.exports = [
     name: 'pathExact',
     handler: (req, actionConfig) => req.url === actionConfig.path,
     schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/pathExact.json',
       type: 'object',
       properties: {
         path: {
@@ -84,6 +90,7 @@ module.exports = [
       }
     },
     schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/method.json',
       type: 'object',
       properties: {
         methods: {
@@ -102,6 +109,7 @@ module.exports = [
       return false;
     },
     schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/hostMatch.json',
       type: 'object',
       properties: {
         pattern: {
@@ -114,6 +122,7 @@ module.exports = [
     name: 'expression',
     handler: (req, conditionConfig) => req.egContext.match(conditionConfig.expression),
     schema: {
+      $id: 'http://express-gateway.io/schemas/conditions/expression.json',
       type: 'object',
       properties: {
         expression: {
@@ -127,16 +136,14 @@ module.exports = [
     name: 'authenticated',
     handler: (req, conditionConfig) => req.isAuthenticated(),
     schema: {
-      type: 'object',
-      properties: {}
+      $id: 'http://express-gateway.io/schemas/conditions/authenticated.json'
     }
   },
   {
     name: 'anonymous',
     handler: (req, conditionConfig) => req.isUnauthenticated(),
     schema: {
-      type: 'object',
-      properties: {}
+      $id: 'http://express-gateway.io/schemas/conditions/anonymous.json'
     }
   }
 ];

--- a/lib/conditions/predefined.js
+++ b/lib/conditions/predefined.js
@@ -92,15 +92,18 @@ module.exports = [
     },
     schema: {
       $id: 'http://express-gateway.io/schemas/conditions/method.json',
+      definitions: {
+        httpMethod: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+        }
+      },
       type: 'object',
       properties: {
         methods: {
-          anyOf: [{
-            type: 'string',
-            enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
-          }, {
+          anyOf: [{ $ref: '#/definitions/httpMethod' }, {
             type: 'array',
-            items: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] }
+            items: { $ref: '#/definitions/httpMethod' }
           }]
         }
       },

--- a/lib/conditions/predefined.js
+++ b/lib/conditions/predefined.js
@@ -62,7 +62,8 @@ module.exports = [
       type: 'object',
       properties: {
         pattern: {
-          type: 'string'
+          type: 'string',
+          format: 'regex'
         }
       },
       required: ['pattern']
@@ -94,8 +95,13 @@ module.exports = [
       type: 'object',
       properties: {
         methods: {
-          type: ['string', 'array'],
-          items: { type: 'string' }
+          anyOf: [{
+            type: 'string',
+            enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+          }, {
+            type: 'array',
+            items: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] }
+          }]
         }
       },
       required: ['methods']

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -50,6 +50,7 @@ class Config {
       this.gatewayConfig = yamlOrJson.load(fs.readFileSync(gatewayConfigPath));
       this.gatewayConfigPath = gatewayConfigPath;
     } catch (err) {
+      log.warn(err);
       try {
         gatewayConfigPath = path.join(process.env.EG_CONFIG_DIR, 'gateway.config.json');
         this.gatewayConfig = yamlOrJson.load(fs.readFileSync(gatewayConfigPath));

--- a/lib/gateway/pipelines.js
+++ b/lib/gateway/pipelines.js
@@ -38,7 +38,7 @@ const ConfigurationError = require('../errors').ConfigurationError;
  * }
  */
 
-module.exports.bootstrap = function ({app, config}) {
+module.exports.bootstrap = function ({ app, config }) {
   if (!validateGatewayConfig(config)) {
     return app;
   }
@@ -143,7 +143,7 @@ function configurePipeline (pipelinePoliciesConfig, config) {
   const router = express.Router({ mergeParams: true });
 
   if (!Array.isArray(pipelinePoliciesConfig)) {
-    pipelinePoliciesConfig = [ pipelinePoliciesConfig ];
+    pipelinePoliciesConfig = [pipelinePoliciesConfig];
   }
   validatePipelinePolicies(pipelinePoliciesConfig, config);
 
@@ -156,7 +156,7 @@ function configurePipeline (pipelinePoliciesConfig, config) {
     }
 
     if (!Array.isArray(policySteps)) {
-      policySteps = [ policySteps ];
+      policySteps = [policySteps];
     }
 
     const policy = policies.resolve(policyName).policy;
@@ -166,14 +166,14 @@ function configurePipeline (pipelinePoliciesConfig, config) {
     }
 
     for (const policyStep of policySteps) {
-      const condition = policyStep.condition;
+      const conditionConfig = policyStep.condition;
 
       // parameters that we pass to the policy at time of execution
       const action = policyStep.action || {};
       Object.assign(action, ActionParams.prototype);
       const policyMiddleware = policy(action, config);
       router.use((req, res, next) => {
-        if (!condition || req.matchEGCondition(condition)) {
+        if (!conditionConfig || req.matchEGCondition(conditionConfig)) {
           log.debug('request matched condition for action', policyStep.action, 'in policy', policyName);
           policyMiddleware(req, res, next);
         } else {
@@ -196,14 +196,14 @@ function validateGatewayConfig (config) {
 
   if (!gatewayConfig.pipelines) {
     if (gatewayConfig.pipeline) {
-      gatewayConfig.pipelines = Array.isArray(gatewayConfig.pipeline) ? gatewayConfig.pipeline : [ gatewayConfig.pipeline ];
+      gatewayConfig.pipelines = Array.isArray(gatewayConfig.pipeline) ? gatewayConfig.pipeline : [gatewayConfig.pipeline];
     } else {
       return false;
     }
   }
   if (!gatewayConfig.apiEndpoints) {
     if (gatewayConfig.apiEndpoint) {
-      gatewayConfig.apiEndpoints = Array.isArray(gatewayConfig.apiEndpoint) ? gatewayConfig.apiEndpoint : [ gatewayConfig.apiEndpoint ];
+      gatewayConfig.apiEndpoints = Array.isArray(gatewayConfig.apiEndpoint) ? gatewayConfig.apiEndpoint : [gatewayConfig.apiEndpoint];
     } else {
       return false;
     }
@@ -217,7 +217,7 @@ function validateGatewayConfig (config) {
     }
 
     if (!Array.isArray(pipeline.apiEndpoints)) {
-      pipeline.apiEndpoints = [ pipeline.apiEndpoints ];
+      pipeline.apiEndpoints = [pipeline.apiEndpoints];
     }
 
     if (!pipeline.policies) {
@@ -225,7 +225,7 @@ function validateGatewayConfig (config) {
     }
 
     if (!Array.isArray(pipeline.policies)) {
-      pipeline.policies = [ pipeline.policies ];
+      pipeline.policies = [pipeline.policies];
     }
   }
 

--- a/lib/policies/basic-auth/index.js
+++ b/lib/policies/basic-auth/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   policy: require('./auth'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/basic-auth.json',
     type: 'object',
     properties: {
       passThrough: { type: 'boolean', default: false }

--- a/lib/policies/cors/cors.js
+++ b/lib/policies/cors/cors.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const cors = require('cors');
 
 module.exports = function (params) {

--- a/lib/policies/cors/index.js
+++ b/lib/policies/cors/index.js
@@ -1,23 +1,24 @@
 module.exports = {
   policy: require('./cors'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/cors.json',
     type: 'object',
     properties: {
       origin: {
         type: ['string', 'boolean', 'array'],
-        items: {type: 'string'}
+        items: { type: 'string' }
       },
       methods: {
         type: ['string', 'array'],
-        items: {type: 'string'}
+        items: { type: 'string' }
       },
       allowedHeaders: {
         type: ['string', 'array'],
-        items: {type: 'string'}
+        items: { type: 'string' }
       },
       exposedHeaders: {
         type: 'array',
-        items: {type: 'string'}
+        items: { type: 'string' }
       },
       credentials: {
         type: 'boolean'

--- a/lib/policies/expression/index.js
+++ b/lib/policies/expression/index.js
@@ -1,10 +1,10 @@
 module.exports = {
   policy: require('./expression'),
   schema: {
-    $id: 'http://express-gateway.io/schemas/expression.json',
+    $id: 'http://express-gateway.io/schemas/policies/expression.json',
     type: 'object',
     properties: {
-      jscode: {$ref: 'defs.json#/definitions/jscode'}
+      jscode: { type: 'string' }
     },
     required: ['jscode']
   }

--- a/lib/policies/headers/headers.js
+++ b/lib/policies/headers/headers.js
@@ -1,15 +1,16 @@
 const logger = require('../../logger').policy;
 module.exports = function (params) {
+  if (!params.forwardHeaders) {
+    logger.warn('No forward headers defined');
+    return (req, res, next) => next();
+  }
+
   return (req, res, next) => {
-    if (params.forwardHeaders) {
-      for (const key in params.forwardHeaders) {
-        const val = params.forwardHeaders[key];
-        // key is new header name that will be prefixed with `headersPrefix`
-        // val is some JS expression to execute against egContext
-        req.headers[params.headersPrefix + key] = req.egContext.run(val);
-      }
-    } else {
-      logger.warn('No forward headers defined');
+    for (const key in params.forwardHeaders) {
+      const val = params.forwardHeaders[key];
+      // key is new header name that will be prefixed with `headersPrefix`
+      // val is some JS expression to execute against egContext
+      req.headers[params.headersPrefix + key] = req.egContext.run(val);
     }
     next();
   };

--- a/lib/policies/headers/headers.js
+++ b/lib/policies/headers/headers.js
@@ -2,12 +2,11 @@ const logger = require('../../logger').policy;
 module.exports = function (params) {
   return (req, res, next) => {
     if (params.forwardHeaders) {
-      const prefix = params.headersPrefix || params.headerPrefix || '';
       for (const key in params.forwardHeaders) {
         const val = params.forwardHeaders[key];
         // key is new header name that will be prefixed with `headersPrefix`
         // val is some JS expression to execute against egContext
-        req.headers[prefix + key] = req.egContext.run(val);
+        req.headers[params.headersPrefix + key] = req.egContext.run(val);
       }
     } else {
       logger.warn('No forward headers defined');

--- a/lib/policies/headers/headers.js
+++ b/lib/policies/headers/headers.js
@@ -1,10 +1,4 @@
-const logger = require('../../logger').policy;
 module.exports = function (params) {
-  if (!params.forwardHeaders) {
-    logger.warn('No forward headers defined in Headers');
-    return (req, res, next) => next();
-  }
-
   return (req, res, next) => {
     for (const key in params.forwardHeaders) {
       const val = params.forwardHeaders[key];

--- a/lib/policies/headers/headers.js
+++ b/lib/policies/headers/headers.js
@@ -1,7 +1,7 @@
 const logger = require('../../logger').policy;
 module.exports = function (params) {
   if (!params.forwardHeaders) {
-    logger.warn('No forward headers defined');
+    logger.warn('No forward headers defined in Headers');
     return (req, res, next) => next();
   }
 

--- a/lib/policies/headers/index.js
+++ b/lib/policies/headers/index.js
@@ -12,6 +12,6 @@ module.exports = {
         type: 'object'
       }
     },
-    required: ['headersPrefix']
+    required: ['headersPrefix', 'forwardHeaders']
   }
 };

--- a/lib/policies/headers/index.js
+++ b/lib/policies/headers/index.js
@@ -5,11 +5,13 @@ module.exports = {
     type: 'object',
     properties: {
       headersPrefix: {
-        type: 'string'
+        type: 'string',
+        default: ''
       },
       forwardHeaders: {
         type: 'object'
       }
-    }
+    },
+    required: ['headersPrefix']
   }
 };

--- a/lib/policies/headers/index.js
+++ b/lib/policies/headers/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   policy: require('./headers'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/headers.json',
     type: 'object',
     properties: {
       headersPrefix: {

--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -32,8 +32,8 @@ class Policies {
       if (validationResult.isValid) {
         return action(params, ...args);
       } else {
-        logger.warn(`warning: policy ${name} params validation failed`, validationResult.error);
-        return null;
+        logger.error(`Policy ${name} params validation failed`, validationResult.error);
+        throw new Error(`Policy ${name} params validation failed`);
       }
     };
 

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -3,7 +3,7 @@ const extractors = require('./extractors');
 module.exports = {
   policy: require('./jwt'),
   schema: {
-    $id: 'http://express-gateway.io/schemas/jwt.json',
+    $id: 'http://express-gateway.io/schemas/policies/jwt.json',
     type: 'object',
     properties: {
       secretOrPublicKey: {

--- a/lib/policies/key-auth/index.js
+++ b/lib/policies/key-auth/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   policy: require('./keyauth'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/keyauth.json',
     type: 'object',
     properties: {
       apiKeyHeader: { type: 'string' },

--- a/lib/policies/log/index.js
+++ b/lib/policies/log/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   policy: require('./log'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/log.json',
     type: 'object',
     properties: {
       message: {

--- a/lib/policies/oauth2/index.js
+++ b/lib/policies/oauth2/index.js
@@ -2,7 +2,7 @@ module.exports = {
   policy: require('./oauth2'),
   routes: require('./oauth2-routes'),
   schema: {
-    $id: 'http://express-gateway.io/schemas/oauth.json',
+    $id: 'http://express-gateway.io/schemas/policies/oauth2.json',
     type: 'object',
     properties: {
       passThrough: { type: 'boolean', default: false },

--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -1,14 +1,14 @@
 module.exports = {
   policy: require('./proxy'),
   schema: {
-    $id: 'http://express-gateway.io/schemas/proxy.json',
+    $id: 'http://express-gateway.io/schemas/policies/proxy.json',
     type: 'object',
     properties: {
       serviceEndpoint: { type: 'string' },
-      changeOrigin: { type: 'boolean' },
+      changeOrigin: { type: 'boolean', default: true },
       proxyUrl: { type: 'string' },
       strategy: { type: 'string', enum: ['round-robin'], default: 'round-robin' }
     },
-    required: ['serviceEndpoint', 'strategy']
+    required: ['serviceEndpoint', 'strategy', 'changeOrigin']
   }
 };

--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -4,10 +4,10 @@ module.exports = {
     $id: 'http://express-gateway.io/schemas/proxy.json',
     type: 'object',
     properties: {
-      serviceEndpoint: {$ref: 'config.json#/gateway/serviceEndpoint'},
-      changeOrigin: {type: 'boolean'},
-      proxyUrl: {type: 'string'},
-      strategy: {type: 'string', enum: ['round-robin']}
+      serviceEndpoint: { type: 'string' },
+      changeOrigin: { type: 'boolean' },
+      proxyUrl: { type: 'string' },
+      strategy: { type: 'string', enum: ['round-robin'] }
     },
     required: ['serviceEndpoint']
   }

--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -7,8 +7,8 @@ module.exports = {
       serviceEndpoint: { type: 'string' },
       changeOrigin: { type: 'boolean' },
       proxyUrl: { type: 'string' },
-      strategy: { type: 'string', enum: ['round-robin'] }
+      strategy: { type: 'string', enum: ['round-robin'], default: 'round-robin' }
     },
-    required: ['serviceEndpoint']
+    required: ['serviceEndpoint', 'strategy']
   }
 };

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -26,9 +26,7 @@ module.exports = function (params, config) {
       'policy configuration) does not contain a `url` or `urls` property');
   }
 
-  const proxy = httpProxy.createProxyServer({
-    changeOrigin: params.changeOrigin !== false
-  });
+  const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin });
 
   proxy.on('error', (err, _req, res) => {
     logger.warn(err);

--- a/lib/policies/rate-limit/index.js
+++ b/lib/policies/rate-limit/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   policy: require('./rate-limit'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/rate-limit.json',
     type: 'object',
     properties: {
       rateLimitBy: { type: 'string' },

--- a/lib/policies/terminate/index.js
+++ b/lib/policies/terminate/index.js
@@ -4,8 +4,9 @@ module.exports = {
     $id: 'http://express-gateway.io/schemas/policies/terminate.json',
     type: 'object',
     properties: {
-      statusCode: { type: 'number' },
-      message: { type: 'string' }
-    }
+      statusCode: { type: 'number', default: 400 },
+      message: { type: 'string', default: 'Terminated' }
+    },
+    required: ['statusCode', 'message']
   }
 };

--- a/lib/policies/terminate/index.js
+++ b/lib/policies/terminate/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   policy: require('./terminate'),
   schema: {
+    $id: 'http://express-gateway.io/schemas/policies/terminate.json',
     type: 'object',
     properties: {
       statusCode: { type: 'number' },

--- a/lib/policies/terminate/terminate.js
+++ b/lib/policies/terminate/terminate.js
@@ -1,7 +1,3 @@
-module.exports = function (params) {
-  params.statusCode = Number(params.statusCode) || 400;
-  params.message = params.message || 'Terminated';
-  return function (req, res, next) {
-    return res.status(params.statusCode).send(params.message);
-  };
-};
+module.exports = (params) =>
+  (req, res, next) =>
+    res.status(params.statusCode).send(params.message);

--- a/lib/rest/routes/schemas.js
+++ b/lib/rest/routes/schemas.js
@@ -3,9 +3,9 @@ const schemas = require('../../schemas');
 
 module.exports = function () {
   const router = express.Router();
-  router.get('/:type?/:name?', function (req, res) {
-    const { type, name } = req.params;
-    res.json(schemas.find(type, name));
+  router.get('/:param?', function (req, res) {
+    const { param } = req.params;
+    res.json(schemas.find(param));
   });
 
   return router;

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -7,16 +7,9 @@ const ajv = new Ajv({
   useDefaults: true
 });
 
-const buildKey = (type, name) => `${type}:${name}`;
-
-const registeredKeys = predefined.map((predefinedSchema) => ({
-  type: 'core',
-  key: predefinedSchema.$id,
-  name: predefinedSchema.$id
-}));
+const registeredKeys = [];
 
 function register (type, name, schema) {
-  const key = buildKey(type, name);
   /*
     This piece of code is checking that the schema isn't already registered.
     This is not optimal and it's happening because the testing helpers aren't
@@ -27,24 +20,31 @@ function register (type, name, schema) {
   if (!schema) {
     logger.warn(`${name} ${type} hasn't provided a schema. Validation for this ${type} will be skipped.`);
     return () => ({ isValid: true });
-  } else if (registeredKeys.findIndex(keys => keys.key === key) === -1) {
-    ajv.addSchema(schema, key);
-    registeredKeys.push({ type, name, key });
+  } else {
+    if (!schema.$id) {
+      throw new Error('The schema must have the $id property.');
+    }
+
+    if (registeredKeys.findIndex(keys => keys.$id === schema.$id) === -1) {
+      ajv.addSchema(schema);
+      registeredKeys.push({ type, $id: schema.$id });
+    }
   }
-  return (data) => ({ isValid: ajv.validate(key, data), error: ajv.errorsText(ajv.errors) });
+
+  return (data) => ({ isValid: ajv.validate(schema.$id, data), error: ajv.errorsText(ajv.errors) });
 }
 
-function find (type = null, name = null) {
-  if (type && name) {
-    const item = ajv.getSchema(buildKey(type, name));
+function find (param = null) {
+  if (param) {
+    const item = ajv.getSchema(param);
     if (item) {
-      return { type, name, schema: item.schema };
+      return { schema: item.schema };
     }
-  } else {
-    return registeredKeys
-      .filter(item => !type || item.type === type)
-      .map(key => ({ key: key.key, type: key.type, name: key.name, schema: ajv.getSchema(key.key).schema }));
   }
+
+  return registeredKeys
+    .filter(item => !param || item.type === param)
+    .map(key => ({ type: key.type, schema: ajv.getSchema(key.$id).schema }));
 }
 
 module.exports = {

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -1,5 +1,6 @@
 const Ajv = require('ajv');
 const predefined = require('./predefined');
+const logger = require('../../lib/logger').gateway;
 
 const ajv = new Ajv({
   schemas: predefined,
@@ -22,11 +23,13 @@ function register (type, name, schema) {
     removing the schemas when we're shutting down the gateway. Hopefully we'll
     get back to this once we'll have a better story for programmatic startup/shutdown
   */
-  if (schema && registeredKeys.findIndex(keys => keys.key === key) === -1) {
+
+  if (!schema) {
+    logger.warn(`${name} ${type} hasn't provided a schema. Validation for this ${type} will be skipped.`);
+  } else if (registeredKeys.findIndex(keys => keys.key === key) === -1) {
     ajv.addSchema(schema, key);
     registeredKeys.push({ type, name, key });
   }
-
   return (data) => validate(type, name, data);
 }
 

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -26,22 +26,12 @@ function register (type, name, schema) {
 
   if (!schema) {
     logger.warn(`${name} ${type} hasn't provided a schema. Validation for this ${type} will be skipped.`);
+    return () => ({ isValid: true });
   } else if (registeredKeys.findIndex(keys => keys.key === key) === -1) {
     ajv.addSchema(schema, key);
     registeredKeys.push({ type, name, key });
   }
-  return (data) => validate(type, name, data);
-}
-
-function validate (type, name, data) {
-  const key = buildKey(type, name);
-  const compiled = ajv.getSchema(key);
-  if (compiled) {
-    const isValid = compiled(data);
-    return { isValid, error: ajv.errorsText(compiled.errors) };
-  }
-
-  return { isValid: true };
+  return (data) => ({ isValid: ajv.validate(key, data), error: ajv.errorsText(ajv.errors) });
 }
 
 function find (type = null, name = null) {
@@ -59,6 +49,5 @@ function find (type = null, name = null) {
 
 module.exports = {
   register,
-  validate,
   find
 };

--- a/lib/schemas/predefined.js
+++ b/lib/schemas/predefined.js
@@ -1,27 +1,12 @@
-const configSchema = {
-  $id: 'http://express-gateway.io/schemas/config.json',
-  gateway: {
-    serviceEndpoint: {type: 'string'}
-  }
-};
-
-const definitionsSchema = {
-  $id: 'http://express-gateway.io/schemas/defs.json',
-  definitions: {
-    jscode: {type: 'string'},
-    condition: {
-      type: 'object',
-      properties: {
-        name: {
-          type: 'string'
-        }
-      },
-      required: ['name']
-    }
-  }
-};
-
 module.exports = [
-  configSchema,
-  definitionsSchema
+  {
+    $id: 'http://express-gateway.io/schemas/conditions/base.json',
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string'
+      }
+    },
+    required: ['name']
+  }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,9 +120,9 @@
       }
     },
     "ajv": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
-      "integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -1479,7 +1479,7 @@
       "integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
       "dev": true,
       "requires": {
-        "ajv": "5.4.0",
+        "ajv": "5.5.1",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
@@ -3175,7 +3175,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.4.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
@@ -8263,7 +8263,7 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.4.0",
+        "ajv": "5.5.1",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,13 +35,10 @@
       }
     },
     "@types/json-schema": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-4.0.0.tgz",
-      "integrity": "sha1-+/bAeDaVRr0V/6eLp/Py4XBIB2k=",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.0.53"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.0.tgz",
+      "integrity": "sha512-pPrN0ECtb1iCz5M47uYefeECFzsSn84pRe9qnYpV9PcIurPlPieJiwhbCito+YiUsX38XydNvIDy0jixSUFlYg==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.0.39",
-    "@types/json-schema": "^4.0.0",
+    "@types/json-schema": "^6.0.0",
     "chai": "3.5.0",
     "codecov": "^2.2.0",
     "cpr": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "types": "./index.d.ts",
   "dependencies": {
-    "ajv": "^5.4.0",
+    "ajv": "^5.5.1",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.2",
     "chalk": "1.1.3",

--- a/test/plugins/condition.test.js
+++ b/test/plugins/condition.test.js
@@ -106,7 +106,7 @@ describe('gateway condition schema with plugins', () => {
     });
   });
 
-  it('should fail on condition schema validation', () => {
+  it('should throw on condition schema validation', () => {
     return gateway({
       plugins: {
         conditions: [{
@@ -128,7 +128,7 @@ describe('gateway condition schema with plugins', () => {
       gatewaySrv = srv.app;
       const req = Object.create(express.request);
       req.url = '/test';
-      assert.isNull(req.matchEGCondition({ name: 'test-condition-2', param1: true }));
+      assert.throw(() => req.matchEGCondition({ name: 'test-condition-2', param1: true }));
     });
   });
 });

--- a/test/plugins/condition.test.js
+++ b/test/plugins/condition.test.js
@@ -84,6 +84,7 @@ describe('gateway condition schema with plugins', () => {
         conditions: [{
           name: 'test-condition-1',
           schema: {
+            $id: 'http://express-gateway.io/schemas/conditions/test-condition-1.json',
             type: 'object',
             properties: {
               param1: { type: ['boolean'] }
@@ -112,6 +113,7 @@ describe('gateway condition schema with plugins', () => {
         conditions: [{
           name: 'test-condition-2',
           schema: {
+            $id: 'http://express-gateway.io/schemas/conditions/test-policy.json',
             type: 'object',
             properties: {
               param2: { type: ['string'] }

--- a/test/plugins/policy.test.js
+++ b/test/plugins/policy.test.js
@@ -114,9 +114,17 @@ describe('gateway policy schema with plugins', () => {
     });
   });
 
-  it('should fail on policy schema validation', function () {
+  it('should throw on policy schema validation', function () {
     config.gatewayConfig.policies.push('test-policy-2');
-    return gateway({
+    config.gatewayConfig.pipelines.pipeline1.policies.push({
+      'test-policy-2': [
+        {
+          action: {}
+        }
+      ]
+    }
+    );
+    return assert.throws(() => gateway({
       plugins: {
         policies: [{
           name: 'test-policy-2',
@@ -133,10 +141,6 @@ describe('gateway policy schema with plugins', () => {
         }]
       },
       config
-    }).then(srv => {
-      helper.setupApp(srv.app);
-      gatewaySrv = srv.app;
-      return srv;
-    });
+    }));
   });
 });

--- a/test/plugins/policy.test.js
+++ b/test/plugins/policy.test.js
@@ -92,6 +92,7 @@ describe('gateway policy schema with plugins', () => {
         policies: [{
           name: 'test-policy',
           schema: {
+            $id: 'http://express-gateway.io/schemas/policies/test-policy.json',
             type: 'object',
             properties: {
               p1: { type: ['number'] }

--- a/test/policies/oauth/consumer-and-token-headers.test.js
+++ b/test/policies/oauth/consumer-and-token-headers.test.js
@@ -49,7 +49,7 @@ describe('Request @headers @proxy downstream @auth @key-auth', () => {
             {
               'headers': [{
                 action: {
-                  headerPrefix: 'eg-',
+                  headersPrefix: 'eg-',
                   forwardHeaders: {
                     'id': 'consumer.id',
                     'consumer-name': 'consumer.name',

--- a/test/rest-api/schemas.test.js
+++ b/test/rest-api/schemas.test.js
@@ -1,12 +1,12 @@
 const { assert } = require('chai');
-const gateway = require('../../lib/gateway');
-const adminHelper = require('../common/admin-helper')();
-const Config = require('../../lib/config/config');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const idGen = require('uuid62');
 const yaml = require('js-yaml');
+const gateway = require('../../lib/gateway');
+const adminHelper = require('../common/admin-helper')();
+const Config = require('../../lib/config/config');
 
 describe('REST: schemas', () => {
   let config;
@@ -44,10 +44,10 @@ describe('REST: schemas', () => {
     it('should list all policy schemas', () => {
       return adminHelper.admin.config.schemas
         .list('policy')
-        .then((schemas) => {
-          const found = schemas.find(schema => schema.name === 'basic-auth');
-          const other = schemas.filter(schema => schema.type !== 'policy');
-          assert.equal(found.name, 'basic-auth');
+        .then((schemasResult) => {
+          const found = schemasResult.find(schemaResult => schemaResult.schema.$id.includes('basic-auth'));
+          const other = schemasResult.filter(schemaResult => schemaResult.type !== 'policy');
+          assert.include(found.schema.$id, 'basic-auth');
           assert.equal(found.type, 'policy');
           assert.isDefined(found.schema);
           assert.equal(other.length, 0);
@@ -56,9 +56,9 @@ describe('REST: schemas', () => {
 
     it('should find basic-auth policy', () => {
       return adminHelper.admin.config.schemas
-        .list('policy', 'basic-auth')
+        .list('http://express-gateway.io/schemas/policies/basic-auth.json')
         .then((schema) => {
-          assert.equal(schema.name, 'basic-auth');
+          assert.include(schema.schema.$id, 'basic-auth');
         });
     });
   });


### PR DESCRIPTION
Connect #484 
Closes #484 

The following monster will reorganize couple of things in the way we leverage the JSON Schemas in the gateway.

Salient points:

* The gateway now refuses to start if the policy configuration is not valid with regards of its JSON Schema 7167c5a3688679f7eadf4a033459cb636096afb9
* The gateway now shows a warning when a policy or a condition is not providing a schema. The gateway will still start (and of course it will skip the validation, but this should encourage the user to provide one) b436480b67b3f74870388b3d129b43be653a7f0f
* Fixed some wrong JSON Schemas b6feb33f41adab8f84c878c253ac1fbb79aa1b34
* I've gone through all policies and conditions and I moved all the possible validations from the code to the JSON Schema
* I've gone through all the schemas and gave them a consistent unique id `http://express-gaetway.io/policy/something.json` or `http://express-gaetway.io/condition/something.json`
* I've modified a bit the API Endpoint for schemas. Given our IDs are now uniques, we do not need such granularity in that anymore (I've discussed the thing with Kristof and it will fulfill his use case)

More details on the intentions can be found in #484 

Have fun :trollface: 