### PR TITLE
Remove models manipulations

### DIFF
--- a/test/e2e/policy-seq-oauth2-expression-log-ratelimit-proxy.js
+++ b/test/e2e/policy-seq-oauth2-expression-log-ratelimit-proxy.js
@@ -7,9 +7,6 @@ const sinon = require('sinon');
 const assert = require('assert');
 
 const logger = require('../../lib/policies/log/winston-logger');
-const credentialModelConfig = require('../../lib/config/models/credentials');
-const userModelConfig = require('../../lib/config/models/users');
-const appModelConfig = require('../../lib/config/models/applications');
 const services = require('../../lib/services');
 const credentialService = services.credential;
 const userService = services.user;
@@ -23,7 +20,6 @@ const originalGatewayConfig = config.gatewayConfig;
 describe('E2E: oauth2, proxy, log, expression, rate-limit policies', () => {
   const helper = testHelper();
   const spy = sinon.spy();
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let user, application, token, app, backendServer;
 
   before('setup', (done) => {
@@ -92,26 +88,6 @@ describe('E2E: oauth2, proxy, log, expression, rate-limit policies', () => {
           ]
         }
       }
-    };
-
-    originalAppConfig = appModelConfig;
-    originalCredentialConfig = credentialModelConfig;
-    originalUserConfig = userModelConfig;
-
-    appModelConfig.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    credentialModelConfig.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    userModelConfig.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
     };
 
     db
@@ -211,9 +187,6 @@ describe('E2E: oauth2, proxy, log, expression, rate-limit policies', () => {
   after('cleanup', (done) => {
     helper.cleanup();
     config.gatewayConfig = originalGatewayConfig;
-    appModelConfig.properties = originalAppConfig.properties;
-    credentialModelConfig.oauth2 = originalCredentialConfig.oauth2;
-    userModelConfig.properties = originalUserConfig.properties;
     logger.info.restore();
     backendServer.close();
     done();

--- a/test/oauth/authorizationcode.test.js
+++ b/test/oauth/authorizationcode.test.js
@@ -3,7 +3,6 @@ const should = require('should');
 const url = require('url');
 const qs = require('querystring');
 const app = require('./bootstrap');
-const config = require('../../lib/config');
 
 const services = require('../../lib/services');
 const credentialService = services.credential;
@@ -13,35 +12,9 @@ const tokenService = services.token;
 const db = require('../../lib/db');
 
 describe('Functional Test Authorization Code grant', function () {
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let fromDbUser1, fromDbApp, refreshToken;
 
   before(function (done) {
-    originalAppConfig = config.models.applications;
-    originalCredentialConfig = config.models.credentials;
-    originalUserConfig = config.models.users;
-
-    config.models.applications.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    config.models.credentials.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    config.models.credentials['basic-auth'] = {
-      passwordKey: 'password',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    config.models.users.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-
     db.flushdb()
       .then(() => {
         const user1 = {
@@ -92,13 +65,6 @@ describe('Functional Test Authorization Code grant', function () {
         should.not.exist(err);
         done();
       });
-  });
-
-  after((done) => {
-    config.models.applications.properties = originalAppConfig.properties;
-    config.models.credentials.oauth2 = originalCredentialConfig.oauth;
-    config.models.users.properties = originalUserConfig.properties;
-    done();
   });
 
   it('should grant access token if requesting without scopes', function (done) {

--- a/test/oauth/client.test.js
+++ b/test/oauth/client.test.js
@@ -1,8 +1,6 @@
 const session = require('supertest-session');
 const should = require('should');
 const app = require('./bootstrap');
-
-const config = require('../../lib/config');
 const services = require('../../lib/services');
 const credentialService = services.credential;
 const userService = services.user;
@@ -11,30 +9,9 @@ const tokenService = services.token;
 const db = require('../../lib/db');
 
 describe('Functional Test Client Credentials grant', function () {
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let user, application;
 
   before(function (done) {
-    originalAppConfig = config.models.applications;
-    originalCredentialConfig = config.models.credentials;
-    originalUserConfig = config.models.users;
-
-    config.models.applications.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    config.models.credentials.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    config.models.users.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-
     db.flushdb()
       .then(() => {
         const user1 = {
@@ -74,13 +51,6 @@ describe('Functional Test Client Credentials grant', function () {
         should.not.exist(err);
         done();
       });
-  });
-
-  after((done) => {
-    config.models.applications.properties = originalAppConfig.properties;
-    config.models.credentials.oauth2 = originalCredentialConfig.oauth;
-    config.models.users.properties = originalUserConfig.properties;
-    done();
   });
 
   it('should grant access token for requests without scopes', function (done) {

--- a/test/oauth/implicit.test.js
+++ b/test/oauth/implicit.test.js
@@ -4,7 +4,6 @@ const url = require('url');
 const qs = require('querystring');
 const app = require('./bootstrap');
 
-const config = require('../../lib/config');
 const services = require('../../lib/services');
 const credentialService = services.credential;
 const userService = services.user;
@@ -13,35 +12,9 @@ const tokenService = services.token;
 const db = require('../../lib/db');
 
 describe('Functional Test Implicit grant', function () {
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let fromDbUser1, fromDbApp;
 
   before(function (done) {
-    originalAppConfig = config.models.applications;
-    originalCredentialConfig = config.models.credentials;
-    originalUserConfig = config.models.users;
-
-    config.models.applications.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    config.models.credentials.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    config.models.credentials['basic-auth'] = {
-      passwordKey: 'password',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    config.models.users.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-
     db.flushdb()
       .then(() => {
         const user1 = {
@@ -92,13 +65,6 @@ describe('Functional Test Implicit grant', function () {
         should.not.exist(err);
         done();
       });
-  });
-
-  after((done) => {
-    config.models.applications.properties = originalAppConfig.properties;
-    config.models.credentials.oauth2 = originalCredentialConfig.oauth;
-    config.models.users.properties = originalUserConfig.properties;
-    done();
   });
 
   it('should grant access token when requesting without scopes', function (done) {

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -2,7 +2,6 @@ const session = require('supertest-session');
 const should = require('should');
 const app = require('./bootstrap');
 
-const config = require('../../lib/config');
 const services = require('../../lib/services');
 const credentialService = services.credential;
 const userService = services.user;
@@ -11,30 +10,9 @@ const tokenService = services.token;
 const db = require('../../lib/db');
 
 describe('Functional Test Client Password grant', function () {
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let fromDbUser1, fromDbApp, refreshToken;
 
   before(function (done) {
-    originalAppConfig = config.models.applications;
-    originalCredentialConfig = config.models.credentials;
-    originalUserConfig = config.models.users;
-
-    config.models.applications.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    config.models.credentials.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    config.models.users.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-
     db.flushdb()
       .then(() => {
         const user1 = {
@@ -87,13 +65,6 @@ describe('Functional Test Client Password grant', function () {
         should.not.exist(err);
         done(err);
       });
-  });
-
-  after((done) => {
-    config.models.applications.properties = originalAppConfig.properties;
-    config.models.credentials.oauth2 = originalCredentialConfig.oauth2;
-    config.models.users.properties = originalUserConfig.properties;
-    done();
   });
 
   it('should grant access token when no scopes are specified', function (done) {

--- a/test/policies/basic-auth-policy.test.js
+++ b/test/policies/basic-auth-policy.test.js
@@ -1,9 +1,6 @@
 const request = require('supertest');
 const should = require('should');
 
-const credentialModelConfig = require('../../lib/config/models/credentials');
-const userModelConfig = require('../../lib/config/models/users');
-const appModelConfig = require('../../lib/config/models/applications');
 const services = require('../../lib/services');
 const credentialService = services.credential;
 const userService = services.user;
@@ -16,7 +13,6 @@ const originalGatewayConfig = config.gatewayConfig;
 
 describe('Functional Tests basic auth Policy', () => {
   const helper = testHelper();
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let user, app;
 
   before('setup', (done) => {
@@ -62,26 +58,6 @@ describe('Functional Tests basic auth Policy', () => {
       }
     };
 
-    originalAppConfig = appModelConfig;
-    originalCredentialConfig = credentialModelConfig;
-    originalUserConfig = userModelConfig;
-
-    appModelConfig.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    credentialModelConfig.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    userModelConfig.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-
     db.flushdb()
       .then(function () {
         const user1 = {
@@ -122,9 +98,6 @@ describe('Functional Tests basic auth Policy', () => {
   after('cleanup', (done) => {
     app.close();
     config.gatewayConfig = originalGatewayConfig;
-    appModelConfig.properties = originalAppConfig.properties;
-    credentialModelConfig.oauth2 = originalCredentialConfig.oauth2;
-    userModelConfig.properties = originalUserConfig.properties;
     helper.cleanup();
     done();
   });

--- a/test/policies/oauth/consumer-and-token-headers.test.js
+++ b/test/policies/oauth/consumer-and-token-headers.test.js
@@ -6,9 +6,6 @@ const express = require('express');
 const sinon = require('sinon');
 const assert = require('assert');
 
-let credentialModelConfig = require('../../../lib/config/models/credentials');
-const userModelConfig = require('../../../lib/config/models/users');
-const appModelConfig = require('../../../lib/config/models/applications');
 const services = require('../../../lib/services/index');
 const credentialService = services.credential;
 const userService = services.user;
@@ -22,7 +19,6 @@ let request;
 describe('Request @headers @proxy downstream @auth @key-auth', () => {
   const helper = testHelper();
   const spy = sinon.spy();
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let user, application, token, app, backendServer;
 
   before('setup', () => {
@@ -70,26 +66,6 @@ describe('Request @headers @proxy downstream @auth @key-auth', () => {
           ]
         }
       }
-    };
-
-    originalAppConfig = appModelConfig;
-    originalCredentialConfig = credentialModelConfig;
-    originalUserConfig = userModelConfig;
-
-    appModelConfig.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    credentialModelConfig.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    userModelConfig.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
     };
 
     return db.flushdb()
@@ -176,9 +152,6 @@ describe('Request @headers @proxy downstream @auth @key-auth', () => {
   after('cleanup', (done) => {
     helper.cleanup();
     config.gatewayConfig = originalGatewayConfig;
-    appModelConfig.properties = originalAppConfig.properties;
-    credentialModelConfig = originalCredentialConfig;
-    userModelConfig.properties = originalUserConfig.properties;
     backendServer.close();
     done();
   });

--- a/test/policies/oauth/oauth-policy.test.js
+++ b/test/policies/oauth/oauth-policy.test.js
@@ -1,9 +1,6 @@
 const session = require('supertest-session');
 const should = require('should');
 
-const credentialModelConfig = require('../../../lib/config/models/credentials');
-const userModelConfig = require('../../../lib/config/models/users');
-const appModelConfig = require('../../../lib/config/models/applications');
 const services = require('../../../lib/services/index');
 const credentialService = services.credential;
 const userService = services.user;
@@ -17,7 +14,6 @@ const originalGatewayConfig = config.gatewayConfig;
 
 describe('Functional Tests oAuth2.0 Policy', () => {
   const helper = testHelper();
-  let originalAppConfig, originalCredentialConfig, originalUserConfig;
   let user, application, token, app;
 
   before('setup', (done) => {
@@ -57,26 +53,6 @@ describe('Functional Tests oAuth2.0 Policy', () => {
           ]
         }
       }
-    };
-
-    originalAppConfig = appModelConfig;
-    originalCredentialConfig = credentialModelConfig;
-    originalUserConfig = userModelConfig;
-
-    appModelConfig.properties = {
-      name: { isRequired: true, isMutable: true },
-      redirectUri: { isRequired: true, isMutable: true }
-    };
-
-    credentialModelConfig.oauth2 = {
-      passwordKey: 'secret',
-      properties: { scopes: { isRequired: false } }
-    };
-
-    userModelConfig.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
     };
 
     db.flushdb()
@@ -146,9 +122,6 @@ describe('Functional Tests oAuth2.0 Policy', () => {
 
   after('cleanup', (done) => {
     config.gatewayConfig = originalGatewayConfig;
-    appModelConfig.properties = originalAppConfig.properties;
-    credentialModelConfig.oauth2 = originalCredentialConfig.oauth2;
-    userModelConfig.properties = originalUserConfig.properties;
     helper.cleanup();
     done();
   });

--- a/test/services/applications.test.js
+++ b/test/services/applications.test.js
@@ -7,21 +7,6 @@ const userService = services.user;
 const db = require('../../lib/db');
 
 describe('Application service tests', function () {
-  let originalUserModelConfig;
-
-  before(function () {
-    originalUserModelConfig = config.models.users.properties;
-    config.models.users.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-  });
-
-  after(function () {
-    config.models.users.properties = originalUserModelConfig;
-  });
-
   describe('Insert tests', function () {
     let user, originalAppModelConfig;
 

--- a/test/services/auth.test.js
+++ b/test/services/auth.test.js
@@ -1,6 +1,4 @@
 const should = require('should');
-const credentialModelConfig = require('../../lib/config/models/credentials');
-const userModelConfig = require('../../lib/config/models/users');
 const services = require('../../lib/services');
 const credentialService = services.credential;
 const userService = services.user;
@@ -10,26 +8,9 @@ const db = require('../../lib/db');
 
 describe('Auth tests', function () {
   let user, userFromDb;
-  const originalModelConfig = credentialModelConfig;
   let _credential;
-  let originalUserModelConfig;
 
   before(() => {
-    credentialModelConfig.oauth2 = {
-      passwordKey: 'secret',
-      autoGeneratePassword: true,
-      properties: {
-        scopes: { isRequired: false }
-      }
-    };
-
-    originalUserModelConfig = userModelConfig.properties;
-    userModelConfig.properties = {
-      firstname: { isRequired: true, isMutable: true },
-      lastname: { isRequired: true, isMutable: true },
-      email: { isRequired: false, isMutable: true }
-    };
-
     return db.flushdb()
       .then(() => {
         user = {
@@ -55,11 +36,6 @@ describe('Auth tests', function () {
         return credentialService.insertCredential(userFromDb.id, 'oauth2', _credential);
       })
       .then((res) => should.exist(res));
-  });
-
-  after(() => {
-    credentialModelConfig.oauth2 = originalModelConfig.oauth2;
-    userModelConfig.properties = originalUserModelConfig;
   });
 
   describe('Credential Auth', () => {

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -8,32 +8,9 @@ const db = require('../../../lib/db');
 describe('Credential service tests', () => {
   describe('Credential tests', () => {
     let credential;
-    const originalModelConfig = config.models.credentials;
     const username = 'someUser';
 
-    before(() => {
-      config.models.credentials.oauth2 = {
-        passwordKey: 'secret',
-        autoGeneratePassword: true,
-        properties: {
-          scopes: { isRequired: false, isMutable: true, defaultVal: null }
-        }
-      };
-
-      config.models.credentials['basic-auth'] = {
-        passwordKey: 'password',
-        autoGeneratePassword: true,
-        properties: {
-          scopes: { isRequired: false, isMutable: true, userDefined: true }
-        }
-      };
-
-      return db.flushdb();
-    });
-
-    after(() => {
-      config.models.credentials = originalModelConfig;
-    });
+    before(() => db.flushdb());
 
     it('should insert a credential', () => {
       const _credential = {
@@ -121,25 +98,8 @@ describe('Credential service tests', () => {
 
   describe('Credential Cascade Delete tests', () => {
     let user;
-    const originalModelConfig = config.models.credentials;
 
     before(() => {
-      config.models.credentials.oauth2 = {
-        passwordKey: 'secret',
-        autoGeneratePassword: true,
-        properties: {
-          scopes: { isRequired: false, isMutable: true, defaultVal: null }
-        }
-      };
-
-      config.models.credentials['basic-auth'] = {
-        passwordKey: 'password',
-        autoGeneratePassword: true,
-        properties: {
-          scopes: { isRequired: false, isMutable: true, userDefined: true }
-        }
-      };
-
       user = {
         username: 'irfanbaqui',
         firstname: 'irfan',
@@ -156,10 +116,6 @@ describe('Credential service tests', () => {
             credentialService.insertCredential(user.id, 'basic-auth').then((basicAuthCred) => should.exist(basicAuthCred.password))
           ]);
         });
-    });
-
-    after(() => {
-      config.models.credentials = originalModelConfig;
     });
 
     it('should delete all credentials associated with a user when user is deleted', () => {


### PR DESCRIPTION
Connect #574 
Connect #556

Given we're moving our model definitions to JSON Schema, it is beneficial to remove all the code that's manipulating the old models for not a good reason — so that the part to refactor will be way less than expected.

I went through the whole test suite and deleted all the parts where things are being redefined for no reasons. In particular, the code I removed is changing/setting the models to the same default value they have anyway. 

Removing those won't harm anybody.