### PR TITLE
Provide migration scrips for old models

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -7,7 +7,6 @@ const YAWN = require('yawn-yaml/cjs');
 const path = require('path');
 const log = require('../logger').config;
 const chokidar = require('chokidar');
-const glob = require('glob');
 const yamlOrJson = require('js-yaml');
 const eventBus = require('../eventBus');
 const schemas = require('../schemas');
@@ -88,7 +87,8 @@ class Config {
   }
 
   loadModels () {
-    glob.sync(path.resolve(process.env.EG_CONFIG_DIR, 'models', '*.json')).forEach(module => {
+    ['users.json', 'credentials.json', 'applications.json'].forEach(model => {
+      const module = path.resolve(process.env.EG_CONFIG_DIR, 'models', model);
       const name = path.basename(module, '.json');
       this.models[name] = require(module);
       schemas.register('model', name, this.models[name]);

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -106,7 +106,10 @@
       }
     },
     "pipelines": {
-      "type": "object",
+      "type": [
+        "object",
+        "array"
+      ],
       "additionalProperties": {
         "type": "object",
         "properties": {

--- a/lib/config/schemas/system.config.json
+++ b/lib/config/schemas/system.config.json
@@ -10,7 +10,7 @@
           "properties": {
             "emulate": {
               "type": "boolean",
-              "default": "true"
+              "default": false
             }
           },
           "required": [

--- a/migrations/1509389756097-model-to-jsonschema.js
+++ b/migrations/1509389756097-model-to-jsonschema.js
@@ -52,13 +52,13 @@ module.exports.up = function () {
                   newModel.required.push(propertyName);
                 }
               });
+            }
 
-              if (modelName === 'users') {
-                newModel.required.push('username');
-                newModel.properties.username = {
-                  type: 'string'
-                };
-              }
+            if (modelName === 'users') {
+              newModel.required.push('username');
+              newModel.properties.username = {
+                type: 'string'
+              };
             }
 
             return { modelName, modelDefinition: newModel };
@@ -69,7 +69,7 @@ module.exports.up = function () {
             )
           )
         )
-    ));
+    ).then(() => Promise.resolve()));
 };
 
 module.exports.down = function (next) {

--- a/migrations/1509389756097-model-to-jsonschema.js
+++ b/migrations/1509389756097-model-to-jsonschema.js
@@ -69,7 +69,10 @@ module.exports.up = function () {
             )
           )
         )
-    ).then(() => Promise.resolve()));
+    ).then(() => {
+      log('Complete', 'You can now remove the old .js files');
+      Promise.resolve();
+    }));
 };
 
 module.exports.down = function (next) {

--- a/migrations/1509389756097-model-to-jsonschema.js
+++ b/migrations/1509389756097-model-to-jsonschema.js
@@ -25,7 +25,7 @@ module.exports.up = function () {
     .then(() => Promise.all(
       [copyFile(path.join(__dirname, '../lib/config/models/credentials.json'), path.join(modelPath, 'credentials.json'))]
         .concat(['users', 'applications']
-          .map(model => ({ modelName: model, modelDefinition: require(path.join(modelPath, model)) }))
+          .map(model => ({ modelName: model, modelDefinition: require(path.join(modelPath, path.format({ name: model, ext: '.js' }))) }))
           .map(({ modelName, modelDefinition }) => {
             const newModel = {
               $id: `http://express-gateway.io/models/${modelName}.json`,

--- a/migrations/1509389756098-credential-username-userid-transform.js
+++ b/migrations/1509389756098-credential-username-userid-transform.js
@@ -1,17 +1,17 @@
-const log = require('migrate/lib/log');
-
-const userService = require('../lib/services/consumers/user.service');
-const credentialService = require('../lib/services/credentials/credential.service');
-const credentialDao = require('../lib/services/credentials/credential.dao');
-
 /*
-  This migration will use the services to deactivate all credentials that are still active and coupled to the username
-  instead of the consumer ID. For each deactived credential, an identical new one will be issued and linked to the user
-  id, making sure the clients will continue to work correctly, as the Admin API's been already modified to change the
-  way it looks up the data.
+This migration will use the services to deactivate all credentials that are still active and coupled to the username
+instead of the consumer ID. For each deactived credential, an identical new one will be issued and linked to the user
+id, making sure the clients will continue to work correctly, as the Admin API's been already modified to change the
+way it looks up the data.
 */
 
 module.exports.up = function () {
+  const log = require('migrate/lib/log');
+
+  const userService = require('../lib/services/consumers/user.service');
+  const credentialService = require('../lib/services/credentials/credential.service');
+  const credentialDao = require('../lib/services/credentials/credential.dao');
+
   return new Promise((resolve, reject) => {
     userService.findAll() // Grab all the users
       .then(({ users }) => {

--- a/migrations/1510050700766-index-applications.js
+++ b/migrations/1510050700766-index-applications.js
@@ -1,14 +1,14 @@
-const log = require('migrate/lib/log');
-const db = require('../lib/db');
-const config = require('../lib/config');
-const userService = require('../lib/services/consumers/user.service');
-const applicationDao = require('../lib/services/consumers/application.dao');
-
 /*
-  This migration index all the applications by adding the relative key in the current Redis instance.
+This migration index all the applications by adding the relative key in the current Redis instance.
 */
 
 module.exports.up = function () {
+  const log = require('migrate/lib/log');
+  const db = require('../lib/db');
+  const config = require('../lib/config');
+  const userService = require('../lib/services/consumers/user.service');
+  const applicationDao = require('../lib/services/consumers/application.dao');
+
   return new Promise((resolve, reject) => {
     userService.findAll() // Grab all the users
       .then(({ users }) => {

--- a/migrations/1515064228642-model-to-jsonschema.js
+++ b/migrations/1515064228642-model-to-jsonschema.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
+require('util.promisify');
+
+const writeFile = util.promisify(fs.writeFile);
+
+module.exports.up = function () {
+  return Promise.all(['users', 'applications']
+    .map(model => ({ modelName: model, modelDefinition: require(path.join(process.env.EG_CONFIG_DIR, model)) }))
+    .map(({ modelName, modelDefinition }) => {
+      const newModel = {
+        type: 'object',
+        properties: {},
+        required: []
+      };
+
+      if (modelDefinition.properties) {
+        Object.entries(modelDefinition.properties).forEach(([propertyName, propertyValue]) => {
+          newModel.properties[propertyName] = {
+            type: 'string'
+          };
+
+          if (propertyValue.isRequired) {
+            newModel.required.push(propertyName);
+          }
+        });
+      }
+
+      return { modelName, modelDefinition: newModel };
+    }).map(({ modelName, modelDefinition }) => writeFile(path.join(process.env.EG_CONFIG_DIR, modelName), modelDefinition)));
+};
+
+module.exports.down = function (next) {
+  throw new Error('I\'m sorry, I can\'t make that happen');
+};

--- a/migrations/1515064228642-model-to-jsonschema.js
+++ b/migrations/1515064228642-model-to-jsonschema.js
@@ -1,14 +1,15 @@
-require('util.promisify/shim')();
-const log = require('migrate/lib/log');
-const path = require('path');
-const fs = require('fs');
-const util = require('util');
-
-const writeFile = util.promisify(fs.writeFile);
-const copyFile = util.promisify(fs.copyFile);
-const access = util.promisify(fs.access);
 
 module.exports.up = function () {
+  require('util.promisify/shim')();
+  const log = require('migrate/lib/log');
+  const path = require('path');
+  const fs = require('fs');
+  const util = require('util');
+
+  const writeFile = util.promisify(fs.writeFile);
+  const copyFile = util.promisify(fs.copyFile);
+  const access = util.promisify(fs.access);
+
   let modelPath;
   if (process.env.EG_CONFIG_DIR) {
     log('modelPath', 'EG_CONFIG_DIR set.');

--- a/migrations/1515064228642-model-to-jsonschema.js
+++ b/migrations/1515064228642-model-to-jsonschema.js
@@ -1,34 +1,69 @@
+require('util.promisify/shim')();
 const path = require('path');
 const fs = require('fs');
 const util = require('util');
-require('util.promisify');
 
 const writeFile = util.promisify(fs.writeFile);
+const copyFile = util.promisify(fs.copyFile);
+const access = util.promisify(fs.access);
 
 module.exports.up = function () {
-  return Promise.all(['users', 'applications']
-    .map(model => ({ modelName: model, modelDefinition: require(path.join(process.env.EG_CONFIG_DIR, model)) }))
-    .map(({ modelName, modelDefinition }) => {
-      const newModel = {
-        type: 'object',
-        properties: {},
-        required: []
-      };
+  let modelPath;
+  if (process.env.EG_CONFIG_DIR) {
+    modelPath = path.join(process.env.EG_CONFIG_DIR, 'models');
+  } else {
+    modelPath = path.join(__dirname, '../../../', 'config/models');
+  }
 
-      if (modelDefinition.properties) {
-        Object.entries(modelDefinition.properties).forEach(([propertyName, propertyValue]) => {
-          newModel.properties[propertyName] = {
-            type: 'string'
-          };
+  return access(modelPath)
+    .then(() => Promise.all(
+      [copyFile(path.resolve('./lib/config/models/credentials.json'), path.join(modelPath, 'credentials.json'))]
+        .concat(['users', 'applications']
+          .map(model => ({ modelName: model, modelDefinition: require(path.join(modelPath, model)) }))
+          .map(({ modelName, modelDefinition }) => {
+            const newModel = {
+              $id: `http://express-gateway.io/models/${modelName}.json`,
+              type: 'object',
+              properties: {},
+              required: []
+            };
 
-          if (propertyValue.isRequired) {
-            newModel.required.push(propertyName);
-          }
-        });
-      }
+            if (modelDefinition.properties) {
+              Object.entries(modelDefinition.properties).forEach(([propertyName, propertyValue]) => {
+                newModel.properties[propertyName] = {
+                  type: 'string'
+                };
 
-      return { modelName, modelDefinition: newModel };
-    }).map(({ modelName, modelDefinition }) => writeFile(path.join(process.env.EG_CONFIG_DIR, modelName), modelDefinition)));
+                if (propertyName === 'email') {
+                  newModel.properties[propertyName].format = 'email';
+                }
+
+                if (propertyName === 'redirectUri') {
+                  newModel.properties[propertyName].format = 'uri';
+                }
+
+                if (propertyValue.isRequired) {
+                  newModel.required.push(propertyName);
+                }
+
+                if (modelName === 'users') {
+                  newModel.required.push('username');
+                  newModel.properties.username = {
+                    type: 'string'
+                  };
+                }
+              });
+            }
+
+            return { modelName, modelDefinition: newModel };
+          }).map(({ modelName, modelDefinition }) =>
+            writeFile(
+              path.join(process.env.EG_CONFIG_DIR, 'models', path.format({ name: modelName, ext: '.json' })),
+              JSON.stringify(modelDefinition, null, 2)
+            )
+          )
+        )
+    ));
 };
 
 module.exports.down = function (next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4923,9 +4923,9 @@
       }
     },
     "migrate": {
-      "version": "1.0.0-3",
-      "resolved": "https://registry.npmjs.org/migrate/-/migrate-1.0.0-3.tgz",
-      "integrity": "sha1-4L2dT9ZxGrRku9wChxN4T/cigPg=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/migrate/-/migrate-1.1.1.tgz",
+      "integrity": "sha512-DpFk9OTxZw973FBIQ1I6ORVyybIyRkhKkJogMwXxW4p3Vn7f2l7fo9l5EZ+36nyuYpe19iJemDX8g/tDHr0TjA==",
       "requires": {
         "chalk": "1.1.3",
         "commander": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "json-schema-merge-allof": "^0.6.0",
     "json-schema-ref-parser": "^4.0.4",
     "jsonwebtoken": "^7.4.3",
-    "migrate": "^1.0.0-2",
+    "migrate": "^1.1.1",
     "minimatch": "^3.0.4",
     "oauth2orize": "^1.11.0",
     "parent-require": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "express-rate-limit": "^2.9.0",
     "express-session": "^1.15.6",
     "find-up": "2.1.0",
-    "glob": "7.1.2",
     "has-flag": "2.0.0",
     "http-proxy": "1.16.2",
     "ioredis": "^3.2.1",

--- a/test/e2e/cli-plugin-install.e2e.test.js
+++ b/test/e2e/cli-plugin-install.e2e.test.js
@@ -44,7 +44,7 @@ describe('E2E: eg plugins install', () => {
         const _cpr = util.promisify(cpr);
         return Promise.all([
           _cpr(gatewayDirectory, tempPath),
-          _cpr(path.join(__dirname, '../../lib/config/models'), path.join(tempPath, 'models'))
+          _cpr(path.join(__dirname, '../../lib/config/models'), path.join(tempPath, 'config', 'models'))
         ]);
       })
       .then(([files]) => {

--- a/test/migrations/credential-username-userid-transform.js
+++ b/test/migrations/credential-username-userid-transform.js
@@ -2,6 +2,7 @@ const migrate = require('migrate');
 const tmp = require('tmp');
 const idGen = require('uuid62');
 const db = require('../../lib/db');
+const fs = require('fs');
 const { assert } = require('chai');
 const userService = require('../../lib/services/consumers/user.service');
 const credentialService = require('../../lib/services/credentials/credential.service');
@@ -28,6 +29,15 @@ describe('Migrations', () => {
 
     before('I then run the migration script', (done) => {
       tmpFile = tmp.fileSync();
+      fs.writeFileSync(tmpFile.name, JSON.stringify({
+        lastRun: '1509389756097-model-to-jsonschema.js',
+        migrations: [
+          {
+            title: '1509389756097-model-to-jsonschema.js',
+            timestamp: 1515423465439
+          }
+        ]
+      }, null, 2));
       migrate.load({ stateStore: tmpFile.name }, (err, set) => {
         if (err) {
           return done(err);


### PR DESCRIPTION
Connect #594 
Closes #594 

This PR will provide a migration script for old models, looping through them and converting them to a JSON Schema equivalent one.

I found one issue on the way: https://github.com/tj/node-migrate/issues/96; I had to make a small trick to make it work properly.

P.S: Legacy is hard.