### PR TITLE
Put better schema defaults to policies

### DIFF
--- a/lib/policies/cors/index.js
+++ b/lib/policies/cors/index.js
@@ -6,11 +6,13 @@ module.exports = {
     properties: {
       origin: {
         type: ['string', 'boolean', 'array'],
-        items: { type: 'string' }
+        items: { type: 'string' },
+        default: '*'
       },
       methods: {
         type: ['string', 'array'],
-        items: { type: 'string' }
+        items: { type: 'string' },
+        default: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE']
       },
       allowedHeaders: {
         type: ['string', 'array'],
@@ -27,7 +29,8 @@ module.exports = {
         type: 'integer'
       },
       optionsSuccessStatus: {
-        type: 'integer'
+        type: 'integer',
+        default: 204
       }
     }
   }

--- a/lib/policies/key-auth/index.js
+++ b/lib/policies/key-auth/index.js
@@ -4,13 +4,13 @@ module.exports = {
     $id: 'http://express-gateway.io/schemas/policies/keyauth.json',
     type: 'object',
     properties: {
-      apiKeyHeader: { type: 'string' },
-      apiKeyHeaderScheme: { type: 'string' },
-      apiKeyField: { type: 'string' },
+      apiKeyHeader: { type: 'string', default: 'Authorization' },
+      apiKeyHeaderScheme: { type: 'string', default: 'apiKey' },
+      apiKeyField: { type: 'string', default: 'apiKey' },
       passThrough: { type: 'boolean', default: false },
-      disableHeaders: { type: 'boolean' },
-      disableHeadersScheme: { type: 'boolean' },
-      disableQueryParam: { type: 'boolean' }
+      disableHeaders: { type: 'boolean', default: false },
+      disableHeadersScheme: { type: 'boolean', default: false },
+      disableQueryParam: { type: 'boolean', default: false }
     }
   }
 };

--- a/lib/policies/key-auth/passport-apikey-strategy.js
+++ b/lib/policies/key-auth/passport-apikey-strategy.js
@@ -8,9 +8,9 @@ function Strategy (options, verify) {
   }
   if (!verify) throw new Error('local authentication strategy requires a verify function');
 
-  this._apiKeyField = options.apiKeyField || 'apiKey';
-  this._apiKeyHeader = options.apiKeyHeader || 'Authorization';
-  this._apiKeyHeaderScheme = options.apiKeyHeaderScheme || 'apiKey';
+  this._apiKeyField = options.apiKeyField;
+  this._apiKeyHeader = options.apiKeyHeader;
+  this._apiKeyHeaderScheme = options.apiKeyHeaderScheme;
 
   passport.Strategy.call(this);
   this.name = 'localapikey';

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -50,17 +50,18 @@ module.exports = function (params, config) {
     const strategy = params.strategy || 'round-robin';
     balancer = createStrategy(strategy, proxyOptions, endpoint.urls);
   }
+
+  const intermediateProxySettings = process.env.http_proxy || params.proxyUrl;
+  if (intermediateProxySettings) {
+    logger.debug(`using intermediate proxy ${intermediateProxySettings}`);
+    proxyOptions.agent = new ProxyAgent(intermediateProxySettings);
+  }
+
   return function proxyHandler (req, res) {
     const targetUrl = balancer.nextTarget();
     proxyOptions.target = Object.assign(proxyOptions.target, targetUrl);
 
     logger.debug(`proxying to ${targetUrl.href}, ${req.method} ${req.url}`);
-
-    const intermediateProxySettings = process.env.http_proxy || params.proxyUrl;
-    if (intermediateProxySettings) {
-      logger.debug(`using intermediate proxy ${intermediateProxySettings}`);
-      proxyOptions.agent = new ProxyAgent(intermediateProxySettings);
-    }
 
     prepareHeaders(params, proxyOptions, req.egContext);
     proxy.web(req, res, proxyOptions);

--- a/lib/policies/rate-limit/index.js
+++ b/lib/policies/rate-limit/index.js
@@ -5,12 +5,12 @@ module.exports = {
     type: 'object',
     properties: {
       rateLimitBy: { type: 'string' },
-      windowMs: { type: 'integer' },
-      delayAfter: { type: 'integer' },
-      delayMs: { type: 'integer' },
-      max: { type: 'integer' },
-      message: { type: 'string' },
-      statusCode: { type: 'integer' }
+      windowMs: { type: 'integer', default: 60000 },
+      delayAfter: { type: 'integer', default: 1 },
+      delayMs: { type: 'integer', default: 1000 },
+      max: { type: 'integer', default: 5 },
+      message: { type: 'string', default: 'Too many requests, please try again later.' },
+      statusCode: { type: 'integer', default: 429 }
     }
   }
 };


### PR DESCRIPTION
The following PR will provide default values for some policies we neglected.

The way I figured out the parameters was to simply check the relative middleware documentation or eventually dig up in the source code to check what values were set if not provided.

Connect #624 
Closes #624

@kolbinski Can you see if these were the policies you were talking about of if there were other more that were concerning you?