### PR TITLE
Pass in logger so it may be consumed by policies

### DIFF
--- a/lib/gateway/pipelines.js
+++ b/lib/gateway/pipelines.js
@@ -2,6 +2,7 @@ const express = require('express');
 const vhost = require('vhost');
 const log = require('../logger').gateway;
 const policies = require('../policies');
+const policyLogger = require('../logger').policy;
 const EgContextBase = require('./context');
 const ActionParams = require('./actionParams');
 
@@ -131,7 +132,7 @@ function configurePipeline (pipelinePoliciesConfig, config) {
       // parameters that we pass to the policy at time of execution
       const action = policyStep.action || {};
       Object.assign(action, ActionParams.prototype);
-      const policyMiddleware = policy(action, config);
+      const policyMiddleware = policy(action, config, policyLogger);
       router.use((req, res, next) => {
         if (!conditionConfig || req.matchEGCondition(conditionConfig)) {
           log.debug('request matched condition for action', policyStep.action, 'in policy', policyName);


### PR DESCRIPTION
Some thoughts I was having while reading the activity on ExpressGateway/express-gateway-plugin-rewrite#9 and it seems like there should be a logger being passed into policy middleware.  I can see where the pluginContext receives a logger, but I saw nothing for policies.  Does an approach like what I have in this PR make sense?

Without this, I suppose it could be possible to do `require('express-gateway/lib/logger')` but I'm not sure if that is necessarily optimal.

I also haven't quite got worked out how to put tests around this yet, just putting this out for discussion for now though.