### PR TITLE
Correctly propagate credential error message to the CLI

### DIFF
--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -8,7 +8,7 @@ module.exports = function () {
     findConsumer(req.body.consumerId)
       .then(consumer => {
         if (!consumer) {
-          return res.status(422).json(new Error('Consumer Not Found: id:' + req.body.consumerId));
+          return res.status(422).send(`No consumer found with id: ${req.body.consumerId}`);
         }
 
         return credentialSrv
@@ -25,7 +25,7 @@ module.exports = function () {
     credentialSrv.getCredential(id, type)
       .then(cred => {
         if (!cred) {
-          return res.status(404).send('credential not found: ' + id);
+          return res.status(404).send(`No credential found with id: ${id}`);
         } else {
           if (cred.isActive === status) {
             return res.json({ status: cred.isActive ? 'Active' : 'Inactive' });

--- a/test/rest-api/credentials.js
+++ b/test/rest-api/credentials.js
@@ -1,0 +1,23 @@
+const should = require('should');
+const adminHelper = require('../common/admin-helper')();
+
+describe('REST: Credentials', () => {
+  before(() => adminHelper.start({
+    config: {
+      gatewayConfig: {
+        admin: { port: 0 },
+        pipelines: null
+      }
+    }
+  }));
+
+  afterEach(() => adminHelper.reset());
+  after(() => adminHelper.stop());
+
+  describe('Insert test', () => {
+    it('should not insert a credential when the consumer does not exist', () =>
+      should(adminHelper.admin.credentials.create('IDoNotExist', 'key-auth', {}))
+        .be.rejectedWith({ response: { error: { text: 'No consumer found with id: IDoNotExist' } } })
+    );
+  });
+});


### PR DESCRIPTION
It turns out that it is not possible to `.json` an Error; they are meant to be thrown and not to be serialized.

This PR will return plain text messages so the CLI can catch these and print them accordingly.

This bug was signaled by @altsang yesterday.