### PR TITLE
Pass policy logger as an action argument

### DIFF
--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -27,7 +27,7 @@ class Policies {
     policy.policy = (params, ...args) => {
       const validationResult = validate(params);
       if (validationResult.isValid) {
-        return action(params, ...args);
+        return action(params, ...args, logger);
       } else {
         logger.error(`Policy ${name} params validation failed`, validationResult.error);
         throw new Error(`Policy ${name} params validation failed`);


### PR DESCRIPTION
Closes #634 

Per the conversation with @DrMegavolt this is my understanding of how the policy logger could be sent to the policy itself.  Then in usage I believe the logger could be accessed like this:

```JavaScript
module.exports = {
  policy: (params, config, logger) => {
  }
  // etc, etc
}
```

What I worry about with this, however, is with how this code could affect `...args`
https://github.com/ExpressGateway/express-gateway/blob/39ca89e4d31b2f9e0cc7d0898683c555b9d0ae2b/lib/gateway/pipelines.js#L134

A change there could then mean that the third parameter could no longer be the logger and could be a breaking change at that point.  Hence why I was thinking it may be better to pass it through pipelines.js instead.  But I leave it as a matter of discussion within this PR for consideration.