### PR TITLE
 Reword policy loading error messages and test the scenario

### DIFF
--- a/lib/gateway/pipelines.js
+++ b/lib/gateway/pipelines.js
@@ -197,7 +197,8 @@ function validatePipelinePolicies (policies, avaiablePolicies) {
     const policyNames = Object.keys(policyObj);
 
     if (avaiablePolicies.indexOf(policyNames[0]) === -1) {
-      throw new Error(`${policyNames[0]} policy not declared`);
+      log.error(`${policyNames[0]} policy not declared in the 'policies' gateway.config section`);
+      throw new Error('POLICY_NOT_DECLARED');
     }
   });
 }

--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -41,8 +41,11 @@ class Policies {
     const policy = this.policies[policyName];
 
     if (!policy) {
-      throw new Error(`Could not find policy ${policyName}, Please check it is listed under "policies" section in gateway.config`);
+      logger.error(`Could not find policy ${policyName}, Please make sure the plugins providing such policy
+       is correctly configured in system.config file.`);
+      throw new Error('POLICY_NOT_FOUND');
     }
+
     return policy;
   }
 }

--- a/test/policies/missing-policy.test.js
+++ b/test/policies/missing-policy.test.js
@@ -1,0 +1,53 @@
+const should = require('should');
+
+const testHelper = require('../common/routing.helper');
+const config = require('../../lib/config');
+const originalGatewayConfig = config.gatewayConfig;
+
+describe('Missing policies', () => {
+  const helper = testHelper();
+  describe('Using a policy that is not installed', () => {
+    before('setup', () => {
+      config.gatewayConfig = {
+        http: { port: 0 },
+        policies: ['rewrite'],
+        pipelines: {
+          pipeline1: {
+            apiEndpoint: 'authorizedEndpoint',
+            policies: [{ rewrite: { action: { serviceEndpoint: 'backend' } } }]
+          }
+        }
+      };
+    });
+
+    it('should prevent the gateway from starting', () => should(() => helper.setup({ config })).throw('POLICY_NOT_FOUND'));
+  });
+
+  describe('Using a policy that is not listed in policies array', () => {
+    before('setup', () => {
+      config.gatewayConfig = {
+        http: { port: 0 },
+        policies: ['basic-auth'],
+        apiEndpoints: {
+          authorizedEndpoint: {
+            host: '*',
+            paths: ['/test']
+          }
+        },
+        pipelines: {
+          pipeline1: {
+            apiEndpoint: 'authorizedEndpoint',
+            policies: [{ proxy: { action: { serviceEndpoint: 'backend' } } }]
+          }
+        }
+      };
+    });
+
+    it('should prevent the gateway from starting', () => should(() => helper.setup({ config })).throw('POLICY_NOT_DECLARED'));
+  });
+
+  afterEach('cleanup', () => {
+    config.gatewayConfig = originalGatewayConfig;
+    return helper.cleanup();
+  });
+});


### PR DESCRIPTION
This PR will make sure to use `log.error` to output error messages and reword them so it should be hopefully more clear.

In particular, we were not mentioning that a policy error might came because of a misconfigured (or missing plugin).

This has been raised after a discussion in the Gitter channel.