### PR TITLE
Forward received JWT data in case credential check is disabled

### DIFF
--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -21,7 +21,7 @@ module.exports = function (params) {
     }
 
     if (!params.checkCredentialExistence) {
-      return done(null, { id: 'anonymous' });
+      return done(null, jwtPayload);
     }
 
     if (!jwtPayload.sub) {


### PR DESCRIPTION
This pull request will make the JWT policy forward the incoming data from a thirty party provider in case the credentials check has been disabled. In this case, the `user` (and `consumer` in egContext) will be populated with such data so we can use it in following policies (such as `headers`).