### PR TITLE
Use native env variables for Redis test instead of mimic them in the code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - image: redis:alpine
     working_directory: ~/repo
     environment:
-      - EG_DB_EMULATE: 0
+      - EG_DB_EMULATE: false
     steps:
       - checkout
       - run: npm install

--- a/lib/config/system.config.yml
+++ b/lib/config/system.config.yml
@@ -1,6 +1,6 @@
 db:
   redis:
-    emulate: true
+    emulate: ${EG_DB_EMULATE:-true}
     host: localhost
     port: 6379
     namespace: EG
@@ -10,7 +10,7 @@ cli:
 
 #plugins:
   # express-gateway-plugin-example:
-  #   param1: 'param from system.config' 
+  #   param1: 'param from system.config'
 
 crypto:
   cipherKey: sensitiveKey

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,11 +5,7 @@ const redisOptions = config.systemConfig.db && config.systemConfig.db.redis;
 
 // special mode, will emulate all redis commands.
 // designed for demo and test scenarious to avoid having real Redis instance
-let emulate = process.argv[2] === 'emulate' || redisOptions.emulate;
-
-if (process.env.EG_DB_EMULATE) {
-  emulate = !!parseInt(process.env.EG_DB_EMULATE);
-}
+const emulate = process.argv[2] === 'emulate' || redisOptions.emulate;
 
 if (redisOptions.tls) {
   if (redisOptions.tls.keyFile) {


### PR DESCRIPTION
Should be self explanatory. Ping me for details, if needed.