### PR TITLE
Emit event before and after executing policy

### DIFF
--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const logger = require('../logger').policy;
 const schemas = require('../schemas');
+const bus = require('../eventBus');
 
 class Policies {
   constructor () {
@@ -27,7 +28,12 @@ class Policies {
     policy.policy = (params, ...args) => {
       const validationResult = validate(params);
       if (validationResult.isValid) {
-        return action(params, ...args);
+        const act = action(params, ...args);
+        return (req, res, next) => {
+          bus.emit('EG::policy::beforePolicy', params, req, res, next);
+          act(req, res, next);
+          bus.emit('EG::policy::afterPolicy', params, req, res, next);
+        };
       } else {
         logger.error(`Policy ${name} params validation failed`, validationResult.error);
         throw new Error(`Policy ${name} params validation failed`);


### PR DESCRIPTION
With @XVincentX help I came up with this, which is related to its feature proposal https://feathub.com/ExpressGateway/express-gateway/+51

IMHO, this can be discussed and improved but I've found it very useful even on this first draft.
Any plugin or app module has to import the same shared eventBus file and attach listeners to it.

Any naming convention for events firing? Other suggestions?