### PR TITLE
Put some order on the credential service

### DIFF
--- a/admin/scopes.js
+++ b/admin/scopes.js
@@ -1,10 +1,10 @@
 module.exports = function (client) {
   const baseUrl = '/scopes/';
   return {
-    create (scope) {
+    create (scopes) {
       return client
         .post(baseUrl)
-        .send({ scope })
+        .send({ scopes })
         .then(res => res.body);
     },
     remove (scope) {

--- a/bin/generators/credentials/create.js
+++ b/bin/generators/credentials/create.js
@@ -15,9 +15,9 @@ module.exports = class extends eg.Generator {
           .usage(`Usage: $0 ${process.argv[2]} create [options]`)
           .example(`$0 ${process.argv[2]} create -c jdoe -t key-auth`)
           .example(`echo '{"consumer":"jdoe", "type": "key-auth"}'` +
-          `| $0 ${process.argv[2]} create --stdin`)
+            `| $0 ${process.argv[2]} create --stdin`)
           .example(`echo '{"consumer":"jdoe", "type": "key-auth", "scopes":["existingScope"]}'` +
-          `| $0 ${process.argv[2]} create --stdin`)
+            `| $0 ${process.argv[2]} create --stdin`)
           .example(`cat all_apps.json | $0 ${process.argv[2]} create --stdin`)
           .example(`$0 ${process.argv[2]} create -u jdoe -p 'scopes=existingScope'`)
           .string(['p', 'c', 't'])
@@ -90,10 +90,13 @@ module.exports = class extends eg.Generator {
     }
 
     return this._promptAndValidate(credential, SCHEMA)
-      .then((credential) => this.admin.credentials.create(argv.consumer, argv.type, credential))
-      .then(newCredential => {
-        this._output(newCredential);
+      .then((credential) => {
+        if (credential.scopes) {
+          credential.scopes = Array.isArray(credential.scopes) ? credential.scopes : [credential.scopes];
+        }
+        return this.admin.credentials.create(argv.consumer, argv.type, credential);
       })
+      .then((data) => this._output(data))
       .catch(err => {
         this.log.error((err.response && err.response.error && err.response.error.text) || err.message);
       });

--- a/bin/generators/scopes/create.js
+++ b/bin/generators/scopes/create.js
@@ -19,18 +19,16 @@ module.exports = class extends eg.Generator {
       ? argv.scope
       : [argv.scope];
 
-    return Promise.all(scopes.map((scope) => {
-      return this.admin.scopes.create(argv.scope)
-        .then(res => {
-          if (argv.q) {
-            this.stdout(`${scope}`);
-          } else {
-            this.log.ok(`Created ${scope}`);
-          }
-        })
-        .catch(err => {
-          this.log.error(err.message);
-        });
-    }));
+    return this.admin.scopes.create(scopes)
+      .then(res => {
+        if (argv.q) {
+          this.stdout(`${scopes}`);
+        } else {
+          this.log.ok(`Created ${scopes}`);
+        }
+      })
+      .catch(err => {
+        this.log.error(err.message);
+      });
   };
 };

--- a/bin/generators/scopes/create.js
+++ b/bin/generators/scopes/create.js
@@ -22,7 +22,7 @@ module.exports = class extends eg.Generator {
     return this.admin.scopes.create(scopes)
       .then(res => {
         if (argv.q) {
-          this.stdout(`${scopes}`);
+          this.stdout(scopes);
         } else {
           this.log.ok(`Created ${scopes}`);
         }

--- a/bin/generators/scopes/create.js
+++ b/bin/generators/scopes/create.js
@@ -28,7 +28,7 @@ module.exports = class extends eg.Generator {
         }
       })
       .catch(err => {
-        this.log.error(err.message);
+        this.log.error(err.response.text);
       });
   };
 };

--- a/lib/rest/routes/credentials.js
+++ b/lib/rest/routes/credentials.js
@@ -55,14 +55,14 @@ module.exports = function () {
     const { id, type, scope } = req.params;
 
     credentialSrv
-      .addScopesToCredential(id, type, scope)
+      .addScopesToCredential(id, type, [scope])
       .then(success => res.status(204).send())
       .catch(next);
   });
 
   router.delete('/:type/:id/scopes/:scope', function (req, res, next) {
     const { id, type, scope } = req.params;
-    credentialSrv.removeScopesFromCredential(id, type, scope)
+    credentialSrv.removeScopesFromCredential(id, type, [scope])
       .then(success => res.status(204).send())
       .catch(next);
   });

--- a/lib/rest/routes/scopes.js
+++ b/lib/rest/routes/scopes.js
@@ -12,8 +12,7 @@ module.exports = function () {
   });
 
   router.post('/', function (req, res, next) {
-    const scope = req.body.scope || req.body.scopes;
-    credentialSrv.insertScopes(scope).then(status => {
+    credentialSrv.insertScopes(req.body.scopes).then(status => {
       res.status(201).send();
       // the only reason it fails - validation for dupes
       // advanced logic requires implementation of error processing in services

--- a/lib/rest/routes/scopes.js
+++ b/lib/rest/routes/scopes.js
@@ -8,7 +8,7 @@ module.exports = function () {
   router.get('/', function (req, res, next) {
     credentialSrv.getAllScopes().then(scopes => {
       res.json({ scopes });
-    }).catch(err => next(err));
+    }).catch(next);
   });
 
   router.post('/', function (req, res, next) {
@@ -30,7 +30,7 @@ module.exports = function () {
           return res.status(404).send('scope not found: ' + req.params.scope);
         }
         res.json({ scope: req.params.scope });
-      }).catch(err => next(err));
+      }).catch(next);
   });
 
   router.put('/:scope', function (req, res, next) {
@@ -51,7 +51,7 @@ module.exports = function () {
         }
         res.status(204).send();
       })
-      .catch(err => { next(err); });
+      .catch(next);
   });
 
   return router;

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -23,12 +23,7 @@ s.insertScopes = function (scopes) {
 };
 
 s.removeScopes = function (scopes) {
-  const _scopes = validateScopes(scopes);
-  if (!_scopes) {
-    throw new Error('invalid scopes'); // TODO: replace with validation error
-  } else {
-    return credentialDao.removeScopes(_scopes).then(v => !!v);
-  }
+  return credentialDao.removeScopes(scopes).then(v => !!v);
 };
 
 s.existsScope = function (scope) {
@@ -234,29 +229,29 @@ s.addScopesToCredential = function (id, type, scopes) {
 };
 
 s.removeScopesFromCredential = function (id, type, scopes) {
-  return Promise.all([validateScopes(scopes), this.getCredential(id, type)])
-    .then(([_scopes, credential]) => {
+  return this.getCredential(id, type)
+    .then((credential) => {
       if (!credential) {
         throw new Error('credential not found');
       }
 
       const existingScopes = credential.scopes ? (Array.isArray(credential.scopes) ? credential.scopes : [credential.scopes]) : [];
-      const newScopes = existingScopes.filter(val => _scopes.indexOf(val) === -1);
+      const newScopes = existingScopes.filter(val => scopes.indexOf(val) === -1);
       return Promise.all([
         credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
-        credentialDao.dissociateCredentialFromScopes(id, type, _scopes)
+        credentialDao.dissociateCredentialFromScopes(id, type, scopes)
       ]).then(() => true);
     });
 };
 
 s.setScopesForCredential = function (id, type, scopes) {
-  return Promise.all([validateScopes(scopes), this.getCredential(id, type)])
-    .then(([_scopes, credential]) => {
+  return this.getCredential(id, type)
+    .then((credential) => {
       if (!credential) {
         throw new Error('credential not found');
       }
 
-      return credentialDao.updateCredential(id, type, { scopes: JSON.stringify(_scopes) });
+      return credentialDao.updateCredential(id, type, { scopes: JSON.stringify(scopes) });
     }).then(() => true);
 };
 
@@ -340,25 +335,18 @@ function validateExistingScopes (scopes) {
 }
 
 function grabScopesAndExecute (scopes, fn) {
-  const _scopes = validateScopes(scopes);
-  if (!_scopes) {
+  if (!scopes) {
     return Promise.reject(new Error('invalid scopes'));
   }
 
-  return Promise.all(_scopes.map(s.existsScope))
+  return Promise.all(scopes.map(s.existsScope))
     .then(res => {
       if (res.every(fn)) {
-        return _scopes;
+        return scopes;
       }
 
       throw new Error('one or more scopes don\'t exist');
     });
-}
-
-function validateScopes (scopes) {
-  if (!scopes || scopes.some(val => typeof val !== 'string')) {
-    return false;
-  } else return scopes;
 }
 
 module.exports = s;

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -334,10 +334,6 @@ function validateExistingScopes (scopes) {
 }
 
 function grabScopesAndExecute (scopes, fn) {
-  if (!scopes) {
-    return Promise.reject(new Error('Invalid scopes'));
-  }
-
   return Promise.all(scopes.map(s.existsScope))
     .then(res => {
       if (res.every(fn)) {

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -356,10 +356,9 @@ function grabScopesAndExecute (scopes, fn) {
 }
 
 function validateScopes (scopes) {
-  const _scopes = Array.isArray(scopes) ? scopes : [scopes];
-  if (!_scopes || _scopes.some(val => typeof val !== 'string')) {
+  if (!scopes || scopes.some(val => typeof val !== 'string')) {
     return false;
-  } else return _scopes;
+  } else return scopes;
 }
 
 module.exports = s;

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -232,10 +232,10 @@ s.removeScopesFromCredential = function (id, type, scopes) {
   return this.getCredential(id, type)
     .then((credential) => {
       if (!credential) {
-        throw new Error('credential not found');
+        throw new Error('Credential not found');
       }
 
-      const newScopes = scopes.filter(val => scopes.indexOf(val) === -1);
+      const newScopes = credential.scopes.filter(val => scopes.indexOf(val) === -1);
       return Promise.all([
         credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
         credentialDao.dissociateCredentialFromScopes(id, type, scopes)

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -235,8 +235,7 @@ s.removeScopesFromCredential = function (id, type, scopes) {
         throw new Error('credential not found');
       }
 
-      const existingScopes = credential.scopes ? (Array.isArray(credential.scopes) ? credential.scopes : [credential.scopes]) : [];
-      const newScopes = existingScopes.filter(val => scopes.indexOf(val) === -1);
+      const newScopes = scopes.filter(val => scopes.indexOf(val) === -1);
       return Promise.all([
         credentialDao.updateCredential(id, type, { scopes: JSON.stringify(newScopes) }),
         credentialDao.dissociateCredentialFromScopes(id, type, scopes)

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -356,7 +356,7 @@ function grabScopesAndExecute (scopes, fn) {
 }
 
 function validateScopes (scopes) {
-  const _scopes = Array.isArray(scopes) ? [...new Set(scopes)] : [scopes];
+  const _scopes = Array.isArray(scopes) ? scopes : [scopes];
   if (!_scopes || _scopes.some(val => typeof val !== 'string')) {
     return false;
   } else return _scopes;

--- a/lib/services/credentials/credential.service.js
+++ b/lib/services/credentials/credential.service.js
@@ -326,16 +326,16 @@ function validateUpdatedCredentialProperties (type, credentialDetails) {
 }
 
 function validateNewScopes (scopes) {
-  return grabScopesAndExecute(scopes, val => !val);
+  return grabScopesAndExecute(scopes, val => !val).catch(() => { throw new Error('One or more scopes already exist.'); });
 }
 
 function validateExistingScopes (scopes) {
-  return grabScopesAndExecute(scopes, val => val);
+  return grabScopesAndExecute(scopes, val => val).catch(() => { throw new Error('One or more scopes don\'t exist'); });
 }
 
 function grabScopesAndExecute (scopes, fn) {
   if (!scopes) {
-    return Promise.reject(new Error('invalid scopes'));
+    return Promise.reject(new Error('Invalid scopes'));
   }
 
   return Promise.all(scopes.map(s.existsScope))
@@ -344,7 +344,7 @@ function grabScopesAndExecute (scopes, fn) {
         return scopes;
       }
 
-      throw new Error('one or more scopes don\'t exist');
+      throw new Error('SCOPE_VALIDATION_FAILED');
     });
 }
 

--- a/test/cli/credential-scopes/add.test.js
+++ b/test/cli/credential-scopes/add.test.js
@@ -27,10 +27,7 @@ describe('eg credential:scopes add', () => {
         cred1 = createdCred;
         scope1 = idGen.v4();
         scope2 = idGen.v4();
-        return Promise.all([
-          adminHelper.admin.scopes.create(scope1),
-          adminHelper.admin.scopes.create(scope2)
-        ]);
+        return adminHelper.admin.scopes.create([scope1, scope2]);
       });
   });
 

--- a/test/cli/credential-scopes/remove.test.js
+++ b/test/cli/credential-scopes/remove.test.js
@@ -17,17 +17,12 @@ describe('eg credential:scopes remove', () => {
     scope1 = idGen.v4();
     scope2 = idGen.v4();
     scope3 = idGen.v4();
-    return Promise.all([
-      adminHelper.admin.scopes.create(scope1),
-      adminHelper.admin.scopes.create(scope2),
-      adminHelper.admin.scopes.create(scope3)
-    ]).then(() => {
-      return adminHelper.admin.users.create({
+    return adminHelper.admin.scopes.create([scope1, scope2, scope3])
+      .then(() => adminHelper.admin.users.create({
         username: idGen.v4(),
         firstname: 'f',
         lastname: 'l'
-      });
-    })
+      }))
       .then(createdUser => {
         user = createdUser;
         return adminHelper.admin.credentials.create(user.id, 'key-auth', {

--- a/test/cli/credential-scopes/set.test.js
+++ b/test/cli/credential-scopes/set.test.js
@@ -17,17 +17,12 @@ describe('eg credential:scopes set', () => {
     scope1 = idGen.v4();
     scope2 = idGen.v4();
     scope3 = idGen.v4();
-    return Promise.all([
-      adminHelper.admin.scopes.create(scope1),
-      adminHelper.admin.scopes.create(scope2),
-      adminHelper.admin.scopes.create(scope3)
-    ]).then(() => {
-      return adminHelper.admin.users.create({
+    return adminHelper.admin.scopes.create([scope1, scope2, scope3])
+      .then(() => adminHelper.admin.users.create({
         username: idGen.v4(),
         firstname: 'f',
         lastname: 'l'
-      });
-    })
+      }))
       .then(createdUser => {
         user = createdUser;
         return adminHelper.admin.credentials.create(user.id, 'key-auth', {

--- a/test/cli/scopes/info.test.js
+++ b/test/cli/scopes/info.test.js
@@ -16,7 +16,7 @@ describe('eg scopes info', () => {
   beforeEach(() => {
     env.prepareHijack();
     scopeName = idGen.v4();
-    return adminHelper.admin.scopes.create(scopeName);
+    return adminHelper.admin.scopes.create([scopeName]);
   });
 
   afterEach(() => {

--- a/test/cli/scopes/remove.test.js
+++ b/test/cli/scopes/remove.test.js
@@ -17,8 +17,7 @@ describe('eg scopes remove', () => {
     env.prepareHijack();
     scopeName = idGen.v4();
     scopeName2 = idGen.v4();
-    return adminHelper.admin.scopes.create(scopeName)
-      .then(() => adminHelper.admin.scopes.create(scopeName2));
+    return adminHelper.admin.scopes.create([scopeName, scopeName2]);
   });
 
   afterEach(() => {

--- a/test/oauth/authorizationcode.test.js
+++ b/test/oauth/authorizationcode.test.js
@@ -48,7 +48,7 @@ describe('Functional Test Authorization Code grant', function () {
                 should.exist(_fromDbApp);
                 fromDbApp = _fromDbApp;
 
-                return credentialService.insertScopes('someScope')
+                return credentialService.insertScopes(['someScope'])
                   .then(() => {
                     return Promise.all([credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
                       credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })])

--- a/test/oauth/client.test.js
+++ b/test/oauth/client.test.js
@@ -36,7 +36,7 @@ describe('Functional Test Client Credentials grant', function () {
                 should.exist(_app);
                 application = _app;
 
-                return credentialService.insertScopes('someScope')
+                return credentialService.insertScopes(['someScope'])
                   .then(() => {
                     credentialService.insertCredential(application.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
                       .then(res => {

--- a/test/oauth/implicit.test.js
+++ b/test/oauth/implicit.test.js
@@ -48,7 +48,7 @@ describe('Functional Test Implicit grant', function () {
                 should.exist(_fromDbApp);
                 fromDbApp = _fromDbApp;
 
-                return credentialService.insertScopes('someScope')
+                return credentialService.insertScopes(['someScope'])
                   .then(() => {
                     return Promise.all([credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
                       credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })])

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -46,7 +46,7 @@ describe('Functional Test Client Password grant', function () {
                 should.exist(_fromDbApp);
                 fromDbApp = _fromDbApp;
 
-                credentialService.insertScopes('someScope')
+                credentialService.insertScopes(['someScope'])
                   .then(() => {
                     Promise.all([
                       credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),

--- a/test/policies/basic-auth-policy.test.js
+++ b/test/policies/basic-auth-policy.test.js
@@ -72,7 +72,7 @@ describe('Functional Tests basic auth Policy', () => {
             should.exist(_fromDbUser1);
             user = _fromDbUser1;
 
-            return credentialService.insertScopes('authorizedScope', 'unauthorizedScope');
+            return credentialService.insertScopes(['authorizedScope', 'unauthorizedScope']);
           })
           .then(() => credentialService.insertCredential(user.id, 'basic-auth', { password: 'user-secret', scopes: ['authorizedScope'] }))
           .then((userRes) => {

--- a/test/policies/keyauth/keyauth.test.js
+++ b/test/policies/keyauth/keyauth.test.js
@@ -105,7 +105,7 @@ describe('Functional Tests keyAuth Policy', () => {
       })
       .then(u => {
         dbuser1 = u;
-        return credentialService.insertScopes('authorizedScope', 'unauthorizedScope');
+        return credentialService.insertScopes(['authorizedScope', 'unauthorizedScope']);
       })
       .then(() => {
         return credentialService.insertCredential(dbuser1.id, 'key-auth', {

--- a/test/policies/passthrough.test.js
+++ b/test/policies/passthrough.test.js
@@ -81,7 +81,7 @@ describe('Functional Tests @auth Policies @passthrough', () => {
       })
       .then(u => {
         dbuser1 = u;
-        return credentialService.insertScopes('authorizedScope', 'unauthorizedScope');
+        return credentialService.insertScopes(['authorizedScope', 'unauthorizedScope']);
       })
       .then(() => {
         return credentialService.insertCredential(dbuser1.id, 'key-auth', {

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -181,7 +181,7 @@ describe('Credential service tests', () => {
 
     it('should not insert a credential with scopes if the scopes are not defined', () => {
       return should(credentialService.insertCredential(username, 'oauth2', _credential))
-        .be.rejectedWith('one or more scopes don\'t exist');
+        .be.rejectedWith('One or more scopes don\'t exist');
     });
 
     it('should insert a credential with scopes if the scopes are defined', () => {
@@ -247,7 +247,7 @@ describe('Credential service tests', () => {
 
     it('should not add scopes to existing credential if the scopes are not defined', () => {
       return should(credentialService.addScopesToCredential(username, 'oauth2', ['undefinedScope']))
-        .be.rejectedWith('one or more scopes don\'t exist');
+        .be.rejectedWith('One or more scopes don\'t exist');
     });
 
     it('should use default property if not defined', () => {

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -158,13 +158,13 @@ describe('Credential service tests', () => {
     const username = 'someUser';
     const _credential = {
       secret: 'password',
-      scopes: 'someScope',
+      scopes: ['someScope'],
       someProperty: 'propVal'
     };
 
     before(() => {
       Object.assign(config.models.credentials.properties.oauth2.properties, {
-        scopes: { type: 'string' },
+        scopes: { type: 'array', items: { tyep: 'string' } },
         someProperty: { type: 'string' },
         otherProperty: { type: 'string', default: 'someDefaultValue' }
       });
@@ -208,7 +208,7 @@ describe('Credential service tests', () => {
               should.exist(cred);
               should.exist(cred.scopes);
               cred.isActive.should.eql(true);
-              cred.scopes.should.containEql(_credential.scopes);
+              cred.scopes.should.containEql(..._credential.scopes);
               cred.scopes.should.containEql('someScope1');
               cred.scopes.should.containEql('someScope2');
               cred.scopes.should.containEql('someScope3');
@@ -224,7 +224,7 @@ describe('Credential service tests', () => {
         .then((cred) => {
           should.exist(cred);
           should.exist(cred.scopes);
-          cred.scopes.should.containEql(_credential.scopes);
+          cred.scopes.should.containEql(..._credential.scopes);
           cred.scopes.should.containEql('someScope1');
           cred.scopes.should.not.containEql('someScope2');
           cred.scopes.should.not.containEql('someScope3');
@@ -246,7 +246,7 @@ describe('Credential service tests', () => {
     });
 
     it('should not add scopes to existing credential if the scopes are not defined', () => {
-      return should(credentialService.addScopesToCredential(username, 'oauth2', 'undefinedScope'))
+      return should(credentialService.addScopesToCredential(username, 'oauth2', ['undefinedScope']))
         .be.rejectedWith('one or more scopes don\'t exist');
     });
 
@@ -254,7 +254,7 @@ describe('Credential service tests', () => {
       const username2 = 'otherUser';
       const cred = {
         secret: 'password',
-        scopes: 'someOtherOne',
+        scopes: ['someOtherOne'],
         someProperty: 'propVal'
       };
 
@@ -275,7 +275,7 @@ describe('Credential service tests', () => {
       const username3 = 'anotherUser';
       const cred = {
         secret: 'password',
-        scopes: 'someScope'
+        scopes: ['someScope']
       };
 
       return should(credentialService

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -185,7 +185,7 @@ describe('Credential service tests', () => {
     });
 
     it('should insert a credential with scopes if the scopes are defined', () => {
-      return credentialService.insertScopes('someScope')
+      return credentialService.insertScopes(['someScope'])
         .then(() => credentialService.insertCredential(username, 'oauth2', _credential))
         .then((newCredential) => {
           should.exist(newCredential);

--- a/test/services/credential-service/credentials.test.js
+++ b/test/services/credential-service/credentials.test.js
@@ -164,7 +164,6 @@ describe('Credential service tests', () => {
 
     before(() => {
       Object.assign(config.models.credentials.properties.oauth2.properties, {
-        scopes: { type: 'array', items: { tyep: 'string' } },
         someProperty: { type: 'string' },
         otherProperty: { type: 'string', default: 'someDefaultValue' }
       });

--- a/test/services/credential-service/scopes.test.js
+++ b/test/services/credential-service/scopes.test.js
@@ -8,7 +8,7 @@ describe('Scope tests', function () {
 
   it('should insert a scope', function (done) {
     credentialService
-      .insertScopes('someScope')
+      .insertScopes(['someScope'])
       .then(function (res) {
         should.exist(res);
         res.should.eql(true);

--- a/test/services/credential-service/scopes.test.js
+++ b/test/services/credential-service/scopes.test.js
@@ -49,7 +49,7 @@ describe('Scope tests', function () {
 
   it('should not insert a scope which is not a string', function (done) {
     credentialService
-      .insertScopes({})
+      .insertScopes([{}])
       .then(function (res) {
         should.not.exist(res);
         done();
@@ -62,7 +62,7 @@ describe('Scope tests', function () {
 
   it('should not insert a scope which is null', function (done) {
     credentialService
-      .insertScopes(null)
+      .insertScopes([null])
       .then(function (res) {
         should.not.exist(res);
         done();


### PR DESCRIPTION
The following pull request will put some orders in our credentials->scopes parts.

In particular:

* There was some confusion on `scope` and `scopes` parameters. The first one was misused and, moreover, undocumented. I've removed it and made sure all the occurrences are using always `scopes` as an array.
* The message when creating the same scope multiple times was broken. Fixed with the correct one.

Connect #666 
Closes #666