### PR TITLE
Set proxy policy parameter changeOrigin to false by default

### DIFF
--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -95,15 +95,29 @@
         "type": "object",
         "properties": {
           "url": {
-            "type": "string"
+            "type": "string",
+            "format": "uri"
           },
           "urls": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           }
-        }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "url"
+            ]
+          },
+          {
+            "required": [
+              "urls"
+            ]
+          }
+        ]
       }
     },
     "policies": {

--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -5,7 +5,7 @@ module.exports = {
     type: 'object',
     properties: {
       serviceEndpoint: { type: 'string' },
-      changeOrigin: { type: 'boolean', default: true },
+      changeOrigin: { type: 'boolean', default: false },
       proxyUrl: { type: 'string' },
       strategy: { type: 'string', enum: ['round-robin'], default: 'round-robin' }
     },

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -18,7 +18,7 @@ module.exports = function (params, config) {
   }
 
   const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);
-  const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin });
+  const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin, ...proxyOptions });
 
   proxy.on('error', (err, req, res) => {
     logger.warn(err);
@@ -51,27 +51,28 @@ module.exports = function (params, config) {
   }
 
   return function proxyHandler (req, res) {
-    const targetUrl = balancer.nextTarget();
-    proxyOptions.target = Object.assign(proxyOptions.target, targetUrl);
+    const target = balancer.nextTarget();
+    const headers = prepareHeaders(req.egContext);
 
-    logger.debug(`proxying to ${targetUrl.href}, ${req.method} ${req.url}`);
+    logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 
-    prepareHeaders(params, proxyOptions, req.egContext);
-    proxy.web(req, res, proxyOptions);
+    proxy.web(req, res, { target, headers });
   };
 
   // multiple urls will load balance, defaulting to round-robin
 };
 
-function prepareHeaders (params, proxyOptions, egContext) {
-  proxyOptions.headers = proxyOptions.headers || {};
+function prepareHeaders (egContext) {
+  const headers = {};
   // Default headers always sent to downstream
   // TODO: allow configuration
   if (egContext.requestId) {
-    proxyOptions.headers['eg-request-id'] = egContext.requestId;
+    headers['eg-request-id'] = egContext.requestId;
   }
-  proxyOptions.headers['eg-consumer-id'] = egContext.consumer && egContext.consumer.id
+  headers['eg-consumer-id'] = egContext.consumer && egContext.consumer.id
     ? egContext.consumer.id : 'anonymous';
+
+  return headers;
 }
 
 // Parse endpoint URL if single URL is provided.

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -14,7 +14,7 @@ module.exports = function (params, config) {
   const endpoint = config.gatewayConfig.serviceEndpoints[serviceEndpointKey];
 
   if (!endpoint) { // Note: one day this can be ensured by JSON Schema, when $data keyword will be avaiable.
-    throw new Error(`service endpoint ${serviceEndpointKey} (referenced in 'proxy' policy configuration) does not exist`);
+    throw new Error(`service endpoint ${serviceEndpointKey} (referenced in proxy policy configuration) does not exist`);
   }
 
   const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -23,10 +23,6 @@ module.exports = function (params, config) {
   proxy.on('error', (err, req, res) => {
     logger.warn(err);
 
-    if (!res) {
-      throw err;
-    }
-
     if (!res.headersSent) {
       res.status(502).send('Bad gateway.');
     } else {

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -25,7 +25,7 @@ module.exports = function (params, config) {
     proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
 
-  const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin, ...proxyOptions });
+  const proxy = httpProxy.createProxyServer(Object.assign({ changeOrigin: params.changeOrigin }, proxyOptions));
 
   proxy.on('error', (err, req, res) => {
     logger.warn(err);

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -52,7 +52,7 @@ module.exports = function (params, config) {
 
   return function proxyHandler (req, res) {
     const target = balancer.nextTarget();
-    const headers = prepareHeaders(req.egContext);
+    const headers = getDefaultHeaders(req.egContext);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 
@@ -62,7 +62,7 @@ module.exports = function (params, config) {
   // multiple urls will load balance, defaulting to round-robin
 };
 
-function prepareHeaders (egContext) {
+function getDefaultHeaders (egContext) {
   const headers = {};
   // Default headers always sent to downstream
   // TODO: allow configuration

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -89,14 +89,17 @@ function parseProxyOptions (proxyOptions = {}, endpoint = {}) {
   if (parsedProxyOptions.target) {
     if (parsedProxyOptions.target.keyFile) {
       parsedProxyOptions.target.key = fs.readFileSync(parsedProxyOptions.target.keyFile);
+      delete parsedProxyOptions.target.keyFile;
     }
 
     if (parsedProxyOptions.target.certFile) {
       parsedProxyOptions.target.cert = fs.readFileSync(parsedProxyOptions.target.certFile);
+      delete parsedProxyOptions.target.certFile;
     }
 
     if (parsedProxyOptions.target.caFile) {
       parsedProxyOptions.target.ca = fs.readFileSync(parsedProxyOptions.target.caFile);
+      delete parsedProxyOptions.target.caFile;
     }
   } else {
     parsedProxyOptions.target = {};

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -46,7 +46,7 @@ module.exports = function (params, config) {
   const intermediateProxyUrl = process.env.HTTP_PROXY || params.proxyUrl;
 
   if (intermediateProxyUrl) {
-    logger.debug(`using intermediate proxy ${intermediateProxyUrl}`);
+    logger.info(`using intermediate proxy ${intermediateProxyUrl}`);
     proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -1,7 +1,7 @@
 const httpProxy = require('http-proxy');
 const fs = require('fs');
 const ProxyAgent = require('proxy-agent');
-const logger = require('../../logger').gateway;
+const logger = require('../../logger').policy;
 const strategies = require('./strategies');
 
 const createStrategy = (strategy, proxyOptions, endpointUrls) => {

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -43,7 +43,8 @@ module.exports = function (params, config) {
 
   const balancer = createStrategy(strategy, proxyOptions, urls);
 
-  const intermediateProxySettings = process.env.http_proxy || params.proxyUrl;
+  const intermediateProxySettings = process.env.HTTP_PROXY || params.proxyUrl;
+
   if (intermediateProxySettings) {
     logger.debug(`using intermediate proxy ${intermediateProxySettings}`);
     proxyOptions.agent = new ProxyAgent(intermediateProxySettings);

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -13,7 +13,7 @@ module.exports = function (params, config) {
   const serviceEndpointKey = params.serviceEndpoint;
   const endpoint = config.gatewayConfig.serviceEndpoints[serviceEndpointKey];
 
-  if (!endpoint) {
+  if (!endpoint) { // Note: one day this can be ensured by JSON Schema, when $data keyword will be avaiable.
     throw new Error(
       `service endpoint ${serviceEndpointKey} (referenced in 'proxy' ` +
       'policy configuration) does not exist');

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -14,15 +14,13 @@ module.exports = function (params, config) {
   const endpoint = config.gatewayConfig.serviceEndpoints[serviceEndpointKey];
 
   if (!endpoint) { // Note: one day this can be ensured by JSON Schema, when $data keyword will be avaiable.
-    throw new Error(
-      `service endpoint ${serviceEndpointKey} (referenced in 'proxy' ` +
-      'policy configuration) does not exist');
+    throw new Error(`service endpoint ${serviceEndpointKey} (referenced in 'proxy' policy configuration) does not exist`);
   }
 
   const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);
   const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin });
 
-  proxy.on('error', (err, _req, res) => {
+  proxy.on('error', (err, req, res) => {
     logger.warn(err);
 
     if (!res) {
@@ -36,14 +34,17 @@ module.exports = function (params, config) {
     }
   });
 
-  let balancer;
+  let strategy;
+  let urls;
   if (endpoint.url) {
-    // single `url` property takes precedence over `urls` array
-    balancer = createStrategy('static', proxyOptions, [endpoint.url]);
+    strategy = 'static';
+    urls = [endpoint.url];
   } else {
-    const strategy = params.strategy || 'round-robin';
-    balancer = createStrategy(strategy, proxyOptions, endpoint.urls);
+    strategy = params.strategy || 'round-robin';
+    urls = endpoint.urls;
   }
+
+  const balancer = createStrategy(strategy, proxyOptions, urls);
 
   const intermediateProxySettings = process.env.http_proxy || params.proxyUrl;
   if (intermediateProxySettings) {

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -18,6 +18,13 @@ module.exports = function (params, config) {
   }
 
   const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);
+  const intermediateProxyUrl = process.env.HTTP_PROXY || params.proxyUrl;
+
+  if (intermediateProxyUrl) {
+    logger.info(`using intermediate proxy ${intermediateProxyUrl}`);
+    proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
+  }
+
   const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin, ...proxyOptions });
 
   proxy.on('error', (err, req, res) => {
@@ -42,13 +49,6 @@ module.exports = function (params, config) {
   }
 
   const balancer = createStrategy(strategy, proxyOptions, urls);
-
-  const intermediateProxyUrl = process.env.HTTP_PROXY || params.proxyUrl;
-
-  if (intermediateProxyUrl) {
-    logger.info(`using intermediate proxy ${intermediateProxyUrl}`);
-    proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
-  }
 
   return function proxyHandler (req, res) {
     const target = balancer.nextTarget();

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -43,11 +43,11 @@ module.exports = function (params, config) {
 
   const balancer = createStrategy(strategy, proxyOptions, urls);
 
-  const intermediateProxySettings = process.env.HTTP_PROXY || params.proxyUrl;
+  const intermediateProxyUrl = process.env.HTTP_PROXY || params.proxyUrl;
 
-  if (intermediateProxySettings) {
-    logger.debug(`using intermediate proxy ${intermediateProxySettings}`);
-    proxyOptions.agent = new ProxyAgent(intermediateProxySettings);
+  if (intermediateProxyUrl) {
+    logger.debug(`using intermediate proxy ${intermediateProxyUrl}`);
+    proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
 
   return function proxyHandler (req, res) {

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -19,11 +19,6 @@ module.exports = function (params, config) {
       'policy configuration) does not exist');
   }
 
-  if (!endpoint.url && !endpoint.urls) {
-    throw new Error(
-      `service endpoint ${serviceEndpointKey} (referenced in 'proxy' ` +
-      'policy configuration) does not contain a `url` or `urls` property');
-  };
   const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);
   const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin });
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -12,7 +12,6 @@ const createStrategy = (strategy, proxyOptions, endpointUrls) => {
 module.exports = function (params, config) {
   const serviceEndpointKey = params.serviceEndpoint;
   const endpoint = config.gatewayConfig.serviceEndpoints[serviceEndpointKey];
-  const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);
 
   if (!endpoint) {
     throw new Error(
@@ -24,8 +23,8 @@ module.exports = function (params, config) {
     throw new Error(
       `service endpoint ${serviceEndpointKey} (referenced in 'proxy' ` +
       'policy configuration) does not contain a `url` or `urls` property');
-  }
-
+  };
+  const proxyOptions = parseProxyOptions(params.proxyOptions, endpoint);
   const proxy = httpProxy.createProxyServer({ changeOrigin: params.changeOrigin });
 
   proxy.on('error', (err, _req, res) => {

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -52,7 +52,7 @@ module.exports = function (params, config) {
 
   return function proxyHandler (req, res) {
     const target = balancer.nextTarget();
-    const headers = getDefaultHeaders(req.egContext);
+    const headers = Object.assign(getDefaultHeaders(req.egContext), proxyOptions.headers);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -32,6 +32,7 @@ module.exports = function (params, config) {
 
   let strategy;
   let urls;
+
   if (endpoint.url) {
     strategy = 'static';
     urls = [endpoint.url];

--- a/lib/policies/proxy/strategies/round-robin.js
+++ b/lib/policies/proxy/strategies/round-robin.js
@@ -15,6 +15,6 @@ module.exports = class RoundRobin {
       this.endpointIndex = 0;
     }
 
-    return url.parse(target);
+    return Object.assign({}, this.proxyOptions.target, url.parse(target));
   }
 };

--- a/lib/policies/proxy/strategies/static.js
+++ b/lib/policies/proxy/strategies/static.js
@@ -8,6 +8,6 @@ module.exports = class StaticProxy {
   }
 
   nextTarget () {
-    return this.target;
+    return Object.assign({}, this.proxyOptions.target, this.target);
   }
 };

--- a/test/e2e/proxy-through-proxy.test.js
+++ b/test/e2e/proxy-through-proxy.test.js
@@ -38,8 +38,8 @@ describe('@e2e @proxy through proxy', () => {
       });
 
       const server = srv.listen(0, () => {
-        process.env.http_proxy = 'http://localhost:' + server.address().port;
-        gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }).then(({gatewayProcess}) => {
+        process.env.HTTP_PROXY = 'http://localhost:' + server.address().port;
+        gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }).then(({ gatewayProcess }) => {
           gw = gatewayProcess;
           done();
         });
@@ -47,10 +47,10 @@ describe('@e2e @proxy through proxy', () => {
     });
   });
   after('cleanup', () => {
-    delete process.env.http_proxy;
+    delete process.env.HTTP_PROXY;
     gw.kill();
   });
-  it('should respect http_proxy env var and send through proxy', () => {
+  it('should respect HTTP_PROXY env var and send through proxy', () => {
     return request
       .get(`http://localhost:${gatewayConfig.http.port}/test`)
       .then((res) => {

--- a/test/e2e/proxy-through-proxy.test.js
+++ b/test/e2e/proxy-through-proxy.test.js
@@ -24,32 +24,41 @@ describe('@e2e @proxy through proxy', () => {
       }
     }
   };
+
   const proxiedUrls = {};
   let gw;
+  let proxy;
+  let srv;
+
   before('init', (done) => {
     cliHelper.bootstrapFolder().then(dirInfo => {
-      const proxy = httpProxy.createProxyServer({
-        changeOrigin: true
-      });
+      proxy = httpProxy.createProxyServer({ changeOrigin: true });
 
-      const srv = http.createServer(function (req, res) {
+      srv = http.createServer(function (req, res) {
         proxiedUrls[req.url] = true;
         proxy.web(req, res, { target: req.url });
       });
 
-      const server = srv.listen(0, () => {
-        process.env.HTTP_PROXY = 'http://localhost:' + server.address().port;
+      const server = srv.listen(0, (err) => {
+        if (err) {
+          return done(err);
+        }
+
+        process.env.HTTP_PROXY = `http://localhost:${server.address().port}`;
         gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }).then(({ gatewayProcess }) => {
           gw = gatewayProcess;
           done();
-        });
+        }).catch(done);
       });
     });
   });
-  after('cleanup', () => {
+
+  after('cleanup', (done) => {
     delete process.env.HTTP_PROXY;
     gw.kill();
+    proxy.close(() => { srv.close(done); });
   });
+
   it('should respect HTTP_PROXY env var and send through proxy', () => {
     return request
       .get(`http://localhost:${gatewayConfig.http.port}/test`)

--- a/test/e2e/proxy-through-proxy.test.js
+++ b/test/e2e/proxy-through-proxy.test.js
@@ -56,7 +56,8 @@ describe('@e2e @proxy through proxy', () => {
   after('cleanup', (done) => {
     delete process.env.HTTP_PROXY;
     gw.kill();
-    proxy.close(() => { srv.close(done); });
+    proxy.close();
+    srv.close(done);
   });
 
   it('should respect HTTP_PROXY env var and send through proxy', () => {

--- a/test/policies/proxy/proxy.test.js
+++ b/test/policies/proxy/proxy.test.js
@@ -80,7 +80,7 @@ describe('@proxy policy', () => {
         });
       });
 
-      after(app.close);
+      after((done) => app.close(done));
 
       it('responds with a bad gateway error', () => {
         return expectedResponse(app, 502, /text\/html/);

--- a/test/policies/proxy/proxy.test.js
+++ b/test/policies/proxy/proxy.test.js
@@ -19,7 +19,7 @@ const chainFile = path.join(__dirname, '../../fixtures/certs/chain', 'chain.pem'
 let backendServerPort;
 
 function expectedResponse (app, status, contentType) {
-  return request(app).get('/endpoint').expect(status).expect('Content-Type', contentType);
+  return request(`http://localhost:${app.address().port}`).get('/endpoint').expect(status).expect('Content-Type', contentType);
 }
 
 describe('@proxy policy', () => {

--- a/test/policies/proxy/proxy.test.js
+++ b/test/policies/proxy/proxy.test.js
@@ -80,9 +80,7 @@ describe('@proxy policy', () => {
         });
       });
 
-      after((done) => {
-        app.close(done);
-      });
+      after(app.close);
 
       it('responds with a bad gateway error', () => {
         return expectedResponse(app, 502, /text\/html/);
@@ -142,10 +140,10 @@ describe('@proxy policy', () => {
   });
 });
 
-function setupGateway (serviceOptions = {}, policyOptions = {}) {
-  return findOpenPortNumbers(1).then((ports) => {
+const setupGateway = (serviceOptions = {}, policyOptions = {}) =>
+  findOpenPortNumbers(1).then(([port]) => {
     config.gatewayConfig = {
-      http: { port: ports[0] },
+      http: { port },
       apiEndpoints: {
         test: {}
       },
@@ -170,4 +168,3 @@ function setupGateway (serviceOptions = {}, policyOptions = {}) {
 
     return gateway();
   });
-}

--- a/test/rest-api/service-endpoint.test.js
+++ b/test/rest-api/service-endpoint.test.js
@@ -48,8 +48,8 @@ describe('REST: service endpoints', () => {
       const initialConfig = {
         admin: { port: 0 },
         serviceEndpoints: {
-          example: { url: 'example.com' },
-          hello: { url: 'hello.com' }
+          example: { url: 'http://example.com' },
+          hello: { url: 'http://hello.com' }
         }
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
@@ -67,8 +67,8 @@ describe('REST: service endpoints', () => {
           const data = fs.readFileSync(config.gatewayConfigPath, 'utf8');
           const cfg = yaml.load(data);
           assert.equal(cfg.serviceEndpoints.test.url, testEndpoint.url);
-          assert.equal(cfg.serviceEndpoints.example.url, 'example.com');
-          assert.equal(cfg.serviceEndpoints.hello.url, 'hello.com');
+          assert.equal(cfg.serviceEndpoints.example.url, 'http://example.com');
+          assert.equal(cfg.serviceEndpoints.hello.url, 'http://hello.com');
           assert(cfg.serviceEndpoints.test.customId);
         });
     });
@@ -100,15 +100,15 @@ describe('REST: service endpoints', () => {
       return adminHelper.admin.config.serviceEndpoints
         .info('example')
         .then((endpoint) => {
-          assert.equal(endpoint.url, 'example.com');
+          assert.equal(endpoint.url, 'http://example.com');
         });
     });
     it('should list all endpoints', () => {
       return adminHelper.admin.config.serviceEndpoints
         .list()
         .then((endpoints) => {
-          assert.equal(endpoints.example.url, 'example.com');
-          assert.equal(endpoints.hello.url, 'hello.com');
+          assert.equal(endpoints.example.url, 'http://example.com');
+          assert.equal(endpoints.hello.url, 'http://hello.com');
           assert.equal(Object.keys(endpoints).length, 2);
         });
     });


### PR DESCRIPTION
This PR will set the default parameter to `false` as it's stated in the documentation and as it should be — so that by default the proxy policy is transparent.

Merge #661 first