### PR TITLE
Explicitly send expires_in field

### DIFF
--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -126,9 +126,7 @@ server.exchange(oauth2orize.exchange.code((consumer, code, redirectUri, done) =>
       }
 
       return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
-        .then(token => {
-          return done(null, token.access_token, token.refresh_token);
-        });
+        .then(token => done(null, token.access_token, token.refresh_token));
     })
     .catch(done);
 }));
@@ -154,29 +152,27 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
             scopeAuthorizationPromise = authService.authorizeCredential(consumer.id, 'oauth2', scopes);
           } else scopeAuthorizationPromise = Promise.resolve(true);
 
-          return scopeAuthorizationPromise
-            .then(authorized => {
-              if (!authorized) return done(null, false);
+          return Promise.all([user, scopeAuthorizationPromise]);
+        })
+        .then(([user, authorized]) => {
+          if (!authorized) return done(null, false);
 
-              const tokenCriteria = {
-                consumerId: consumer.id,
-                authenticatedUser: user.id
-              };
+          const tokenCriteria = {
+            consumerId: consumer.id,
+            authenticatedUser: user.id
+          };
 
-              if (scopes) tokenCriteria.scopes = scopes;
+          if (scopes) tokenCriteria.scopes = scopes;
 
-              if (config.systemConfig.accessTokens.tokenType === 'jwt') {
-                return tokenService
-                  .createJWT({ consumerId: consumer.id, scopes })
-                  .then(res => done(null, res))
-                  .catch(done);
-              }
+          if (config.systemConfig.accessTokens.tokenType === 'jwt') {
+            return tokenService
+              .createJWT({ consumerId: consumer.id, scopes })
+              .then(res => done(null, res))
+              .catch(done);
+          }
 
-              return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
-                .then(token => {
-                  return done(null, token.access_token, token.refresh_token);
-                });
-            });
+          return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
+            .then(token => done(null, token.access_token, token.refresh_token));
         })
         .catch(done);
     });
@@ -199,29 +195,27 @@ server.exchange(oauth2orize.exchange.clientCredentials((consumer, scopes, done) 
         scopeAuthorizationPromise = authService.authorizeCredential(consumer.id, 'oauth2', scopes);
       } else scopeAuthorizationPromise = Promise.resolve(true);
 
-      return scopeAuthorizationPromise
-        .then(authorized => {
-          if (!authorized) return done(null, false);
+      return scopeAuthorizationPromise;
+    })
+    .then(authorized => {
+      if (!authorized) return done(null, false);
 
-          const tokenCriteria = {
-            consumerId: consumer.id,
-            authType: 'oauth2'
-          };
+      const tokenCriteria = {
+        consumerId: consumer.id,
+        authType: 'oauth2'
+      };
 
-          if (scopes) tokenCriteria.scopes = scopes;
+      if (scopes) tokenCriteria.scopes = scopes;
 
-          if (config.systemConfig.accessTokens.tokenType === 'jwt') {
-            return tokenService
-              .createJWT({ consumerId: consumer.id, scopes })
-              .then(res => done(null, res))
-              .catch(done);
-          }
+      if (config.systemConfig.accessTokens.tokenType === 'jwt') {
+        return tokenService
+          .createJWT({ consumerId: consumer.id, scopes })
+          .then(res => done(null, res))
+          .catch(done);
+      }
 
-          return tokenService.findOrSave(tokenCriteria)
-            .then(token => {
-              return done(null, token.access_token);
-            });
-        });
+      return tokenService.findOrSave(tokenCriteria)
+        .then(token => done(null, token.access_token, null));
     })
     .catch(done);
 }));
@@ -234,18 +228,17 @@ server.exchange(oauth2orize.exchange.refreshToken(function (consumer, refreshTok
         return done(null, false);
       }
 
-      return tokenService.getTokenObject(refreshToken)
-        .then(tokenObj => {
-          if (!tokenObj) {
-            return done(null, false);
-          }
+      return tokenService.getTokenObject(refreshToken);
+    })
+    .then(tokenObj => {
+      if (!tokenObj) {
+        return done(null, false);
+      }
 
-          return tokenService.findOrSave(tokenObj)
-            .then(token => {
-              return done(null, token.access_token);
-            });
-        });
-    }).catch(done);
+      return tokenService.findOrSave(tokenObj)
+        .then(token => done(null, token.access_token, null));
+    })
+    .catch(done);
 }));
 
 // User authorization endpoint.

--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -144,15 +144,9 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
 
       return authService.authenticateCredential(username, password, 'basic-auth')
         .then(user => {
-          let scopeAuthorizationPromise;
-
           if (!user) return done(null, false);
 
-          if (scopes) {
-            scopeAuthorizationPromise = authService.authorizeCredential(consumer.id, 'oauth2', scopes);
-          } else scopeAuthorizationPromise = Promise.resolve(true);
-
-          return Promise.all([user, scopeAuthorizationPromise]);
+          return Promise.all([user, scopes ? authService.authorizeCredential(consumer.id, 'oauth2', scopes) : true]);
         })
         .then(([user, authorized]) => {
           if (!authorized) return done(null, false);

--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -232,7 +232,7 @@ server.exchange(oauth2orize.exchange.refreshToken(function (consumer, refreshTok
       }
 
       return tokenService.findOrSave(tokenObj)
-        .then(token => done(null, token.access_token, null));
+        .then(token => done(null, token.access_token, null, { expires_in: expiresIn }));
     })
     .catch(done);
 }));

--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -9,6 +9,8 @@ const tokenService = services.token;
 const authCodeService = services.authorizationCode;
 const authService = services.auth;
 
+const expiresIn = config.systemConfig.accessTokens.timeToExpiry / 1000;
+
 // Create OAuth 2.0 server
 const server = oauth2orize.createServer();
 
@@ -126,7 +128,7 @@ server.exchange(oauth2orize.exchange.code((consumer, code, redirectUri, done) =>
       }
 
       return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
-        .then(token => done(null, token.access_token, token.refresh_token));
+        .then(token => done(null, token.access_token, token.refresh_token, { expires_in: expiresIn }));
     })
     .catch(done);
 }));
@@ -166,7 +168,7 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
           }
 
           return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
-            .then(token => done(null, token.access_token, token.refresh_token));
+            .then(token => done(null, token.access_token, token.refresh_token, { expires_in: expiresIn }));
         })
         .catch(done);
     });

--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -211,7 +211,7 @@ server.exchange(oauth2orize.exchange.clientCredentials((consumer, scopes, done) 
       }
 
       return tokenService.findOrSave(tokenCriteria)
-        .then(token => done(null, token.access_token, null));
+        .then(token => done(null, token.access_token, null, { expires_in: expiresIn }));
     })
     .catch(done);
 }));

--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -144,34 +144,34 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
     .then(consumer => {
       if (!consumer) return done(null, false);
 
-      return authService.authenticateCredential(username, password, 'basic-auth')
-        .then(user => {
-          if (!user) return done(null, false);
+      return authService.authenticateCredential(username, password, 'basic-auth');
+    })
+    .then(user => {
+      if (!user) return done(null, false);
 
-          return Promise.all([user, scopes ? authService.authorizeCredential(consumer.id, 'oauth2', scopes) : true]);
-        })
-        .then(([user, authorized]) => {
-          if (!authorized) return done(null, false);
+      return Promise.all([user, scopes ? authService.authorizeCredential(consumer.id, 'oauth2', scopes) : true]);
+    })
+    .then(([user, authorized]) => {
+      if (!authorized) return done(null, false);
 
-          const tokenCriteria = {
-            consumerId: consumer.id,
-            authenticatedUser: user.id
-          };
+      const tokenCriteria = {
+        consumerId: consumer.id,
+        authenticatedUser: user.id
+      };
 
-          if (scopes) tokenCriteria.scopes = scopes;
+      if (scopes) tokenCriteria.scopes = scopes;
 
-          if (config.systemConfig.accessTokens.tokenType === 'jwt') {
-            return tokenService
-              .createJWT({ consumerId: consumer.id, scopes })
-              .then(res => done(null, res))
-              .catch(done);
-          }
+      if (config.systemConfig.accessTokens.tokenType === 'jwt') {
+        return tokenService
+          .createJWT({ consumerId: consumer.id, scopes })
+          .then(res => done(null, res))
+          .catch(done);
+      }
 
-          return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
-            .then(token => done(null, token.access_token, token.refresh_token, { expires_in: expiresIn }));
-        })
-        .catch(done);
-    });
+      return tokenService.findOrSave(tokenCriteria, { includeRefreshToken: true })
+        .then(token => done(null, token.access_token, token.refresh_token, { expires_in: expiresIn }));
+    })
+    .catch(done);
 }));
 
 // Exchange the client id and password/secret for an access token. The callback accepts the

--- a/test/oauth/authorizationcode.test.js
+++ b/test/oauth/authorizationcode.test.js
@@ -10,9 +10,9 @@ const { checkTokenResponse, createOAuthScenario } = require('./testUtils');
 const tokenService = services.token;
 
 describe('Functional Test Authorization Code grant', function () {
-  let fromDbApp, refreshToken;
+  let fromDbApp, fromDbUser, refreshToken;
 
-  before(() => createOAuthScenario().then(([user, app]) => { fromDbApp = app; }));
+  before(() => createOAuthScenario().then(([user, app]) => { fromDbUser = user; fromDbApp = app; }));
 
   it('should grant access token if requesting without scopes', function (done) {
     const request = session(app);
@@ -32,7 +32,7 @@ describe('Functional Test Authorization Code grant', function () {
         request
           .post('/login')
           .query({
-            username: 'irfanbaqui',
+            username: fromDbUser.username,
             password: 'user-secret'
           })
           .expect(302)
@@ -101,7 +101,7 @@ describe('Functional Test Authorization Code grant', function () {
         request
           .post('/login')
           .query({
-            username: 'irfanbaqui',
+            username: fromDbUser.username,
             password: 'user-secret'
           })
           .expect(302)
@@ -204,7 +204,7 @@ describe('Functional Test Authorization Code grant', function () {
         request
           .post('/login')
           .query({
-            username: 'irfanbaqui',
+            username: fromDbUser.username,
             password: 'user-secret'
           })
           .expect(302)

--- a/test/oauth/bootstrap.js
+++ b/test/oauth/bootstrap.js
@@ -1,9 +1,8 @@
-'use strict';
-
 const express = require('express');
 const config = require('../../lib/config');
-
 const oauth2 = require('../../lib/policies/oauth2/oauth2-routes');
-const app = express();
+require('../../lib/policies/oauth2/oauth2');
+require('../../lib/policies/basic-auth/basic-auth');
 
+const app = express();
 module.exports = oauth2(app, config);

--- a/test/oauth/checkTokenResponse.js
+++ b/test/oauth/checkTokenResponse.js
@@ -3,4 +3,6 @@ const should = require('should');
 module.exports = (response, additionalProps = []) => {
   should(response).have.properties('access_token', 'expires_in', ...additionalProps);
   should(response.token_type).be.eql('Bearer');
+  should(response.access_token.length).be.greaterThan(15);
+  should(response.refresh_token.length).be.greaterThan(15);
 };

--- a/test/oauth/checkTokenResponse.js
+++ b/test/oauth/checkTokenResponse.js
@@ -4,5 +4,4 @@ module.exports = (response, additionalProps = []) => {
   should(response).have.properties('access_token', 'expires_in', ...additionalProps);
   should(response.token_type).be.eql('Bearer');
   should(response.access_token.length).be.greaterThan(15);
-  should(response.refresh_token.length).be.greaterThan(15);
 };

--- a/test/oauth/checkTokenResponse.js
+++ b/test/oauth/checkTokenResponse.js
@@ -1,7 +1,0 @@
-const should = require('should');
-
-module.exports = (response, additionalProps = []) => {
-  should(response).have.properties('access_token', 'expires_in', ...additionalProps);
-  should(response.token_type).be.eql('Bearer');
-  should(response.access_token.length).be.greaterThan(15);
-};

--- a/test/oauth/checkTokenResponse.js
+++ b/test/oauth/checkTokenResponse.js
@@ -1,0 +1,6 @@
+const should = require('should');
+
+module.exports = (response, additionalProps = []) => {
+  should(response).have.properties('access_token', 'expires_in', ...additionalProps);
+  should(response.token_type).be.eql('Bearer');
+};

--- a/test/oauth/client.test.js
+++ b/test/oauth/client.test.js
@@ -2,63 +2,15 @@ const session = require('supertest-session');
 const should = require('should');
 
 const app = require('./bootstrap');
-const checkTokenResponse = require('./checkTokenResponse');
+const { checkTokenResponse, createOAuthScenario } = require('./testUtils');
 const services = require('../../lib/services');
-const db = require('../../lib/db');
 
-const credentialService = services.credential;
-const userService = services.user;
-const applicationService = services.application;
 const tokenService = services.token;
 
 describe('Functional Test Client Credentials grant', function () {
-  let fromDbUser1, fromDbApp;
+  let fromDbApp;
 
-  const user1 = {
-    username: 'irfanbaqui',
-    firstname: 'irfan',
-    lastname: 'baqui',
-    email: 'irfan@eg.com'
-  };
-
-  const user2 = {
-    username: 'somejoe',
-    firstname: 'joe',
-    lastname: 'smith',
-    email: 'joe@eg.com'
-  };
-
-  before(() =>
-    db.flushdb()
-      .then(() => Promise.all([userService.insert(user1), userService.insert(user2)]))
-      .then(([_fromDbUser1, _fromDbUser2]) => {
-        should.exist(_fromDbUser1);
-        should.exist(_fromDbUser2);
-
-        fromDbUser1 = _fromDbUser1;
-
-        const app1 = {
-          name: 'irfan_app',
-          redirectUri: 'https://some.host.com/some/route'
-        };
-
-        return applicationService.insert(app1, fromDbUser1.id);
-      })
-      .then(_fromDbApp => {
-        should.exist(_fromDbApp);
-        fromDbApp = _fromDbApp;
-
-        return credentialService.insertScopes(['someScope']);
-      })
-      .then(() => Promise.all([
-        credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
-        credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
-      ]))
-      .then(([userRes, appRes]) => {
-        should.exist(userRes);
-        should.exist(appRes);
-      })
-  );
+  before(() => createOAuthScenario().then(([user, app]) => { fromDbApp = app; }));
 
   it('should grant access token for requests without scopes', function (done) {
     const request = session(app);

--- a/test/oauth/implicit.test.js
+++ b/test/oauth/implicit.test.js
@@ -14,58 +14,51 @@ const db = require('../../lib/db');
 describe('Functional Test Implicit grant', function () {
   let fromDbUser1, fromDbApp;
 
-  before(function (done) {
+  const user1 = {
+    username: 'irfanbaqui',
+    firstname: 'irfan',
+    lastname: 'baqui',
+    email: 'irfan@eg.com'
+  };
+
+  const user2 = {
+    username: 'somejoe',
+    firstname: 'joe',
+    lastname: 'smith',
+    email: 'joe@eg.com'
+  };
+
+  before(() =>
     db.flushdb()
-      .then(() => {
-        const user1 = {
-          username: 'irfanbaqui',
-          firstname: 'irfan',
-          lastname: 'baqui',
-          email: 'irfan@eg.com'
+      .then(() => Promise.all([userService.insert(user1), userService.insert(user2)]))
+      .then(([_fromDbUser1, _fromDbUser2]) => {
+        should.exist(_fromDbUser1);
+        should.exist(_fromDbUser2);
+
+        fromDbUser1 = _fromDbUser1;
+
+        const app1 = {
+          name: 'irfan_app',
+          redirectUri: 'https://some.host.com/some/route'
         };
 
-        const user2 = {
-          username: 'somejoe',
-          firstname: 'joe',
-          lastname: 'smith',
-          email: 'joe@eg.com'
-        };
-
-        Promise.all([userService.insert(user1), userService.insert(user2)])
-          .then(([_fromDbUser1, _fromDbUser2]) => {
-            should.exist(_fromDbUser1);
-            should.exist(_fromDbUser2);
-
-            fromDbUser1 = _fromDbUser1;
-
-            const app1 = {
-              name: 'irfan_app',
-              redirectUri: 'https://some.host.com/some/route'
-            };
-
-            applicationService.insert(app1, fromDbUser1.id)
-              .then(_fromDbApp => {
-                should.exist(_fromDbApp);
-                fromDbApp = _fromDbApp;
-
-                return credentialService.insertScopes(['someScope'])
-                  .then(() => {
-                    return Promise.all([credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
-                      credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })])
-                      .then(([userRes, appRes]) => {
-                        should.exist(userRes);
-                        should.exist(appRes);
-                        done();
-                      });
-                  });
-              });
-          });
+        return applicationService.insert(app1, fromDbUser1.id);
       })
-      .catch(function (err) {
-        should.not.exist(err);
-        done();
-      });
-  });
+      .then(_fromDbApp => {
+        should.exist(_fromDbApp);
+        fromDbApp = _fromDbApp;
+
+        return credentialService.insertScopes(['someScope']);
+      })
+      .then(() => Promise.all([
+        credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
+        credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
+      ]))
+      .then(([userRes, appRes]) => {
+        should.exist(userRes);
+        should.exist(appRes);
+      })
+  );
 
   it('should grant access token when requesting without scopes', function (done) {
     const request = session(app);
@@ -228,10 +221,7 @@ describe('Functional Test Implicit grant', function () {
                 scope: 'someScope, someUnauthorizedScope'
               })
               .expect(403)
-              .end(function (err) {
-                should.not.exist(err);
-                done();
-              });
+              .end(done);
           });
       });
   });

--- a/test/oauth/implicit.test.js
+++ b/test/oauth/implicit.test.js
@@ -9,9 +9,9 @@ const { createOAuthScenario } = require('./testUtils');
 const tokenService = services.token;
 
 describe('Functional Test Implicit grant', function () {
-  let fromDbApp;
+  let fromDbApp, fromDbUser;
 
-  before(() => createOAuthScenario().then(([user, app]) => { fromDbApp = app; }));
+  before(() => createOAuthScenario().then(([user, app]) => { fromDbUser = user; fromDbApp = app; }));
 
   it('should grant access token when requesting without scopes', function (done) {
     const request = session(app);
@@ -31,7 +31,7 @@ describe('Functional Test Implicit grant', function () {
         request
           .post('/login')
           .query({
-            username: 'irfanbaqui',
+            username: fromDbUser.username,
             password: 'user-secret'
           })
           .expect(302)
@@ -94,7 +94,7 @@ describe('Functional Test Implicit grant', function () {
         request
           .post('/login')
           .query({
-            username: 'irfanbaqui',
+            username: fromDbUser.username,
             password: 'user-secret'
           })
           .expect(302)
@@ -157,7 +157,7 @@ describe('Functional Test Implicit grant', function () {
         request
           .post('/login')
           .query({
-            username: 'irfanbaqui',
+            username: fromDbUser.username,
             password: 'user-secret'
           })
           .expect(302)

--- a/test/oauth/implicit.test.js
+++ b/test/oauth/implicit.test.js
@@ -5,60 +5,13 @@ const qs = require('querystring');
 const app = require('./bootstrap');
 
 const services = require('../../lib/services');
-const credentialService = services.credential;
-const userService = services.user;
-const applicationService = services.application;
+const { createOAuthScenario } = require('./testUtils');
 const tokenService = services.token;
-const db = require('../../lib/db');
 
 describe('Functional Test Implicit grant', function () {
-  let fromDbUser1, fromDbApp;
+  let fromDbApp;
 
-  const user1 = {
-    username: 'irfanbaqui',
-    firstname: 'irfan',
-    lastname: 'baqui',
-    email: 'irfan@eg.com'
-  };
-
-  const user2 = {
-    username: 'somejoe',
-    firstname: 'joe',
-    lastname: 'smith',
-    email: 'joe@eg.com'
-  };
-
-  before(() =>
-    db.flushdb()
-      .then(() => Promise.all([userService.insert(user1), userService.insert(user2)]))
-      .then(([_fromDbUser1, _fromDbUser2]) => {
-        should.exist(_fromDbUser1);
-        should.exist(_fromDbUser2);
-
-        fromDbUser1 = _fromDbUser1;
-
-        const app1 = {
-          name: 'irfan_app',
-          redirectUri: 'https://some.host.com/some/route'
-        };
-
-        return applicationService.insert(app1, fromDbUser1.id);
-      })
-      .then(_fromDbApp => {
-        should.exist(_fromDbApp);
-        fromDbApp = _fromDbApp;
-
-        return credentialService.insertScopes(['someScope']);
-      })
-      .then(() => Promise.all([
-        credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
-        credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
-      ]))
-      .then(([userRes, appRes]) => {
-        should.exist(userRes);
-        should.exist(appRes);
-      })
-  );
+  before(() => createOAuthScenario().then(([user, app]) => { fromDbApp = app; }));
 
   it('should grant access token when requesting without scopes', function (done) {
     const request = session(app);

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -12,60 +12,51 @@ const db = require('../../lib/db');
 describe('Functional Test Client Password grant', function () {
   let fromDbUser1, fromDbApp, refreshToken;
 
-  before(function (done) {
+  const user1 = {
+    username: 'irfanbaqui',
+    firstname: 'irfan',
+    lastname: 'baqui',
+    email: 'irfan@eg.com'
+  };
+
+  const user2 = {
+    username: 'somejoe',
+    firstname: 'joe',
+    lastname: 'smith',
+    email: 'joe@eg.com'
+  };
+
+  before(() =>
     db.flushdb()
-      .then(() => {
-        const user1 = {
-          username: 'irfanbaqui',
-          firstname: 'irfan',
-          lastname: 'baqui',
-          email: 'irfan@eg.com'
+      .then(() => Promise.all([userService.insert(user1), userService.insert(user2)]))
+      .then(([_fromDbUser1, _fromDbUser2]) => {
+        should.exist(_fromDbUser1);
+        should.exist(_fromDbUser2);
+
+        fromDbUser1 = _fromDbUser1;
+
+        const app1 = {
+          name: 'irfan_app',
+          redirectUri: 'https://some.host.com/some/route'
         };
 
-        const user2 = {
-          username: 'somejoe',
-          firstname: 'joe',
-          lastname: 'smith',
-          email: 'joe@eg.com'
-        };
-
-        return Promise.all([userService.insert(user1), userService.insert(user2)])
-          .then(([_fromDbUser1, _fromDbUser2]) => {
-            should.exist(_fromDbUser1);
-            should.exist(_fromDbUser2);
-
-            fromDbUser1 = _fromDbUser1;
-
-            const app1 = {
-              name: 'irfan_app',
-              redirectUri: 'https://some.host.com/some/route'
-            };
-
-            applicationService.insert(app1, fromDbUser1.id)
-              .then(_fromDbApp => {
-                should.exist(_fromDbApp);
-                fromDbApp = _fromDbApp;
-
-                credentialService.insertScopes(['someScope'])
-                  .then(() => {
-                    Promise.all([
-                      credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
-                      credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
-                    ])
-                      .then(([userRes, appRes]) => {
-                        should.exist(userRes);
-                        should.exist(appRes);
-                        done();
-                      });
-                  });
-              });
-          });
+        return applicationService.insert(app1, fromDbUser1.id);
       })
-      .catch(function (err) {
-        should.not.exist(err);
-        done(err);
-      });
-  });
+      .then(_fromDbApp => {
+        should.exist(_fromDbApp);
+        fromDbApp = _fromDbApp;
+
+        return credentialService.insertScopes(['someScope']);
+      })
+      .then(() => Promise.all([
+        credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
+        credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
+      ]))
+      .then(([userRes, appRes]) => {
+        should.exist(userRes);
+        should.exist(appRes);
+      })
+  );
 
   it('should grant access token when no scopes are specified', function (done) {
     const request = session(app);

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -8,9 +8,9 @@ const { checkTokenResponse, createOAuthScenario } = require('./testUtils');
 const tokenService = services.token;
 
 describe('Functional Test Client Password grant', function () {
-  let fromDbApp, refreshToken;
+  let fromDbApp, fromDbUser, refreshToken;
 
-  before(() => createOAuthScenario().then(([user, app]) => { fromDbApp = app; }));
+  before(() => createOAuthScenario().then(([user, app]) => { fromDbUser = user; fromDbApp = app; }));
 
   it('should grant access token when no scopes are specified', function (done) {
     const request = session(app);
@@ -23,7 +23,7 @@ describe('Functional Test Client Password grant', function () {
       .type('form')
       .send({
         grant_type: 'password',
-        username: 'irfanbaqui',
+        username: fromDbUser.username,
         password: 'user-secret'
       })
       .expect(200)
@@ -45,7 +45,7 @@ describe('Functional Test Client Password grant', function () {
       .type('form')
       .send({
         grant_type: 'password',
-        username: 'irfanbaqui',
+        username: fromDbUser.username,
         password: 'user-secret',
         scope: 'someScope'
       })
@@ -102,7 +102,7 @@ describe('Functional Test Client Password grant', function () {
       .type('form')
       .send({
         grant_type: 'password',
-        username: 'irfanbaqui',
+        username: fromDbUser.username,
         password: 'user-secret',
         scope: 'someScope unauthorizedScope'
       })

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -3,62 +3,14 @@ const should = require('should');
 
 const app = require('./bootstrap');
 const services = require('../../lib/services');
-const db = require('../../lib/db');
-const checkTokenResponse = require('./checkTokenResponse');
+const { checkTokenResponse, createOAuthScenario } = require('./testUtils');
 
-const credentialService = services.credential;
-const userService = services.user;
-const applicationService = services.application;
 const tokenService = services.token;
 
 describe('Functional Test Client Password grant', function () {
-  let fromDbUser1, fromDbApp, refreshToken;
+  let fromDbApp, refreshToken;
 
-  const user1 = {
-    username: 'irfanbaqui',
-    firstname: 'irfan',
-    lastname: 'baqui',
-    email: 'irfan@eg.com'
-  };
-
-  const user2 = {
-    username: 'somejoe',
-    firstname: 'joe',
-    lastname: 'smith',
-    email: 'joe@eg.com'
-  };
-
-  before(() =>
-    db.flushdb()
-      .then(() => Promise.all([userService.insert(user1), userService.insert(user2)]))
-      .then(([_fromDbUser1, _fromDbUser2]) => {
-        should.exist(_fromDbUser1);
-        should.exist(_fromDbUser2);
-
-        fromDbUser1 = _fromDbUser1;
-
-        const app1 = {
-          name: 'irfan_app',
-          redirectUri: 'https://some.host.com/some/route'
-        };
-
-        return applicationService.insert(app1, fromDbUser1.id);
-      })
-      .then(_fromDbApp => {
-        should.exist(_fromDbApp);
-        fromDbApp = _fromDbApp;
-
-        return credentialService.insertScopes(['someScope']);
-      })
-      .then(() => Promise.all([
-        credentialService.insertCredential(fromDbUser1.id, 'basic-auth', { password: 'user-secret' }),
-        credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
-      ]))
-      .then(([userRes, appRes]) => {
-        should.exist(userRes);
-        should.exist(appRes);
-      })
-  );
+  before(() => createOAuthScenario().then(([user, app]) => { fromDbApp = app; }));
 
   it('should grant access token when no scopes are specified', function (done) {
     const request = session(app);

--- a/test/oauth/password.test.js
+++ b/test/oauth/password.test.js
@@ -73,7 +73,7 @@ describe('Functional Test Client Password grant', function () {
 
     request
       .post('/oauth2/token')
-      .set('Authorization', 'basic ' + credentials)
+      .set('Authorization', `basic ${credentials}`)
       .set('content-type', 'application/x-www-form-urlencoded')
       .type('form')
       .send({

--- a/test/oauth/testUtils.js
+++ b/test/oauth/testUtils.js
@@ -1,4 +1,5 @@
 const should = require('should');
+const uuid = require('uuid62');
 
 const services = require('../../lib/services');
 const db = require('../../lib/db');
@@ -16,7 +17,7 @@ module.exports = {
 
   createOAuthScenario: () => {
     const user1 = {
-      username: 'irfanbaqui',
+      username: uuid.v4(),
       firstname: 'irfan',
       lastname: 'baqui',
       email: 'irfan@eg.com'

--- a/test/oauth/testUtils.js
+++ b/test/oauth/testUtils.js
@@ -1,0 +1,58 @@
+const should = require('should');
+
+const services = require('../../lib/services');
+const db = require('../../lib/db');
+
+const credentialService = services.credential;
+const userService = services.user;
+const applicationService = services.application;
+
+module.exports = {
+  checkTokenResponse: (response, additionalProps = []) => {
+    should(response).have.properties('access_token', 'expires_in', ...additionalProps);
+    should(response.token_type).be.eql('Bearer');
+    should(response.access_token.length).be.greaterThan(15);
+  },
+
+  createOAuthScenario: () => {
+    const user1 = {
+      username: 'irfanbaqui',
+      firstname: 'irfan',
+      lastname: 'baqui',
+      email: 'irfan@eg.com'
+    };
+
+    const app1 = {
+      name: 'irfan_app',
+      redirectUri: 'https://some.host.com/some/route'
+    };
+
+    let fromDbUser, fromDbApp;
+
+    return db.flushdb()
+      .then(() => userService.insert(user1))
+      .then((_fromDbUser) => {
+        should.exist(_fromDbUser);
+
+        fromDbUser = _fromDbUser;
+
+        return applicationService.insert(app1, fromDbUser.id);
+      })
+      .then(_fromDbApp => {
+        should.exist(_fromDbApp);
+        fromDbApp = _fromDbApp;
+
+        return credentialService.insertScopes(['someScope']);
+      })
+      .then(() => Promise.all([
+        credentialService.insertCredential(fromDbUser.id, 'basic-auth', { password: 'user-secret' }),
+        credentialService.insertCredential(fromDbApp.id, 'oauth2', { secret: 'app-secret', scopes: ['someScope'] })
+      ]))
+      .then(([userRes, appRes]) => {
+        should.exist(userRes);
+        should.exist(appRes);
+
+        return [fromDbUser, fromDbApp];
+      });
+  }
+};


### PR DESCRIPTION
Connect #679
Closes #679

The following PR will make sure to explicitly set the `expires_in` field in all the oAuth2 responses.

While developing this change, I realized how much code for the tests scenario was copied and pasted here and there, making changes almost impossible (copy and paste the things around 5-6 times). I've extracted such code in a shared file that's now used around.