### PR TITLE
Use gateway output instead of timers to signal the gateway is ready

### DIFF
--- a/bin/generators/tokens/revoke.js
+++ b/bin/generators/tokens/revoke.js
@@ -9,7 +9,7 @@ module.exports = class extends eg.Generator {
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} revoke [options] <tokens..>`)
-          .positional('tokens')
+          .positional('tokens', { type: 'array' })
     });
   }
 

--- a/test/common/gateway.helper.js
+++ b/test/common/gateway.helper.js
@@ -50,7 +50,7 @@ module.exports.startGatewayInstance = function ({ dirInfo, gatewayConfig }) {
         const gatewayProcess = fork(modulePath, [], {
           cwd: dirInfo.basePath,
           env: childEnv,
-          stdio: 'pipe'
+          stdio: ['pipe', 'pipe', 'pipe', 'ipc']
         });
 
         gatewayProcess.on('error', reject);

--- a/test/common/gateway.helper.js
+++ b/test/common/gateway.helper.js
@@ -49,30 +49,23 @@ module.exports.startGatewayInstance = function ({ dirInfo, gatewayConfig }) {
           'lib', 'index.js');
         const gatewayProcess = fork(modulePath, [], {
           cwd: dirInfo.basePath,
-          env: childEnv
+          env: childEnv,
+          stdio: 'pipe'
         });
 
-        gatewayProcess.on('error', err => {
-          reject(err);
-        });
-        let count = 0;
-        const interval = setInterval(() => {
-          count++; // Waiting for process to start, ignoring conn refused errors
+        gatewayProcess.on('error', reject);
+        gatewayProcess.stdout.on('data', () => {
           request
             .get(`http://localhost:${gatewayPort}/not-found`)
             .end((err, res) => {
-              if (err && res && res.statusCode === 404) {
-                clearInterval(interval);
+              if (res && res.statusCode === 404) {
                 resolve({ gatewayProcess, gatewayPort, adminPort, backendPort, dirInfo });
               } else {
-                if (count >= 25) {
-                  gatewayProcess.kill();
-                  clearInterval(interval);
-                  reject(new Error('Failed to start Express Gateway'));
-                }
+                gatewayProcess.kill();
+                reject(err);
               }
             });
-        }, 300);
+        });
       });
     });
 };


### PR DESCRIPTION
Connect #672 
Connect #694 
Closes #694 


This PR will change the way we signal to the test framework that the gateway is ready. Instead of making multiple attempts separated by a timeout, we'll wait till the gateway will output the ready sentences.

This should decrease a bit the flakyness of our tests.