### PR TITLE
DRY the startGatewayInstance function in tests

### DIFF
--- a/test/common/gateway.helper.js
+++ b/test/common/gateway.helper.js
@@ -24,14 +24,14 @@ module.exports.getYmlConfig = function ({ ymlConfigPath }) {
 module.exports.startGatewayInstance = function ({ dirInfo, gatewayConfig, backendServers = 1 }) {
   return findOpenPortNumbers(2 + backendServers)
     .then(ports => {
-      gatewayPort = ports[0];
-      adminPort = ports[1];
-      backendPorts = ports[2];
+      gatewayPort = ports.shift();
+      adminPort = ports.shift();
+      backendPorts = ports;
 
       gatewayConfig.http = { port: gatewayPort };
       gatewayConfig.admin = { port: adminPort };
       gatewayConfig.serviceEndpoints = gatewayConfig.serviceEndpoints || {};
-      gatewayConfig.serviceEndpoints.backend.urls = backendPorts.map(backendPort => `http://localhost:${backendPort}`);
+      gatewayConfig.serviceEndpoints.backend = { urls: backendPorts.map(backendPort => `http://localhost:${backendPort}`) };
 
       return this.setYmlConfig({
         ymlConfigPath: dirInfo.gatewayConfigPath,
@@ -66,7 +66,14 @@ module.exports.startGatewayInstance = function ({ dirInfo, gatewayConfig, backen
                 gatewayProcess.kill();
                 reject(err);
               }
-              resolve({ gatewayProcess, gatewayPort, adminPort, backendPorts, dirInfo, backendServers });
+              resolve({
+                gatewayProcess,
+                gatewayPort,
+                adminPort,
+                backendPorts,
+                dirInfo,
+                backendServers: backendServers.map(bs => bs.app)
+              });
             });
         });
       });

--- a/test/common/gateway.helper.js
+++ b/test/common/gateway.helper.js
@@ -22,11 +22,11 @@ module.exports.getYmlConfig = function ({ ymlConfigPath }) {
 };
 
 module.exports.startGatewayInstance = function ({ dirInfo, gatewayConfig }) {
-  return findOpenPortNumbers(4)
+  return findOpenPortNumbers(3)
     .then(ports => {
       gatewayPort = ports[0];
-      backendPort = ports[1];
-      adminPort = ports[2];
+      adminPort = ports[1];
+      backendPort = ports[2];
 
       gatewayConfig.http = { port: gatewayPort };
       gatewayConfig.admin = { port: adminPort };

--- a/test/e2e/basic-auth.e2e.test.js
+++ b/test/e2e/basic-auth.e2e.test.js
@@ -1,7 +1,7 @@
 const cliHelper = require('../common/cli.helper');
 const gwHelper = require('../common/gateway.helper');
 const request = require('supertest');
-let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServer;
+let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServers;
 const username = 'test';
 const proxyPolicy = {
   proxy: { action: { serviceEndpoint: 'backend' } }
@@ -41,7 +41,7 @@ describe('E2E: basic-auth Policy', () => {
       .then(dirInfo => gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }))
       .then(gwInfo => {
         gatewayProcess = gwInfo.gatewayProcess;
-        backendServer = gwInfo.backendServer;
+        backendServers = gwInfo.backendServers;
         gatewayPort = gwInfo.gatewayPort;
         adminPort = gwInfo.adminPort;
         configDirectoryPath = gwInfo.dirInfo.configDirectoryPath;
@@ -73,7 +73,7 @@ describe('E2E: basic-auth Policy', () => {
 
   after((done) => {
     gatewayProcess.kill();
-    backendServer.close(done);
+    backendServers[0].close(done);
   });
 
   it('should not authenticate token for requests without token header', function () {

--- a/test/e2e/basic-auth.e2e.test.js
+++ b/test/e2e/basic-auth.e2e.test.js
@@ -1,7 +1,7 @@
 const cliHelper = require('../common/cli.helper');
 const gwHelper = require('../common/gateway.helper');
 const request = require('supertest');
-let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServers;
+let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServer;
 const username = 'test';
 const proxyPolicy = {
   proxy: { action: { serviceEndpoint: 'backend' } }
@@ -41,7 +41,7 @@ describe('E2E: basic-auth Policy', () => {
       .then(dirInfo => gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }))
       .then(gwInfo => {
         gatewayProcess = gwInfo.gatewayProcess;
-        backendServers = gwInfo.backendServers;
+        backendServer = gwInfo.backendServers[0];
         gatewayPort = gwInfo.gatewayPort;
         adminPort = gwInfo.adminPort;
         configDirectoryPath = gwInfo.dirInfo.configDirectoryPath;
@@ -73,7 +73,7 @@ describe('E2E: basic-auth Policy', () => {
 
   after((done) => {
     gatewayProcess.kill();
-    backendServers[0].close(done);
+    backendServer.close(done);
   });
 
   it('should not authenticate token for requests without token header', function () {

--- a/test/e2e/key-auth.e2e.test.js
+++ b/test/e2e/key-auth.e2e.test.js
@@ -6,7 +6,7 @@ const idGen = require('uuid62');
 const username = idGen.v4();
 const headerName = 'Authorization';
 
-let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServer;
+let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServers;
 let keyCred;
 
 const proxyPolicy = {
@@ -74,7 +74,7 @@ describe('E2E: key-auth Policy', () => {
       return gwHelper.startGatewayInstance({ dirInfo, gatewayConfig });
     }).then(gwInfo => {
       gatewayProcess = gwInfo.gatewayProcess;
-      backendServer = gwInfo.backendServer;
+      backendServers = gwInfo.backendServers;
       gatewayPort = gwInfo.gatewayPort;
       adminPort = gwInfo.adminPort;
       configDirectoryPath = gwInfo.dirInfo.configDirectoryPath;
@@ -108,7 +108,7 @@ describe('E2E: key-auth Policy', () => {
 
   after((done) => {
     gatewayProcess.kill();
-    backendServer.close(done);
+    backendServers[0].close(done);
   });
 
   it('should not authenticate key for requests without authorization header', function () {

--- a/test/e2e/key-auth.e2e.test.js
+++ b/test/e2e/key-auth.e2e.test.js
@@ -6,7 +6,7 @@ const idGen = require('uuid62');
 const username = idGen.v4();
 const headerName = 'Authorization';
 
-let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServers;
+let gatewayPort, adminPort, configDirectoryPath, gatewayProcess, backendServer;
 let keyCred;
 
 const proxyPolicy = {
@@ -74,7 +74,7 @@ describe('E2E: key-auth Policy', () => {
       return gwHelper.startGatewayInstance({ dirInfo, gatewayConfig });
     }).then(gwInfo => {
       gatewayProcess = gwInfo.gatewayProcess;
-      backendServers = gwInfo.backendServers;
+      backendServer = gwInfo.backendServers[0];
       gatewayPort = gwInfo.gatewayPort;
       adminPort = gwInfo.adminPort;
       configDirectoryPath = gwInfo.dirInfo.configDirectoryPath;
@@ -108,7 +108,7 @@ describe('E2E: key-auth Policy', () => {
 
   after((done) => {
     gatewayProcess.kill();
-    backendServers[0].close(done);
+    backendServer.close(done);
   });
 
   it('should not authenticate key for requests without authorization header', function () {

--- a/test/e2e/oauth2-authorization-code.js
+++ b/test/e2e/oauth2-authorization-code.js
@@ -21,7 +21,7 @@ describe('oauth2 authorization code grant type', () => {
 
   let gatewayProcess = null;
 
-  let gatewayPort, adminPort, redirectPort, redirectServer, backendServers;
+  let gatewayPort, adminPort, redirectPort, redirectServer, backendServer;
 
   before(function () {
     const gatewayConfig = {
@@ -81,7 +81,7 @@ describe('oauth2 authorization code grant type', () => {
       .then(gwInfo => {
         tempPath = gwInfo.dirInfo.configDirectoryPath;
         gatewayProcess = gwInfo.gatewayProcess;
-        backendServers = gwInfo.backendServers;
+        backendServer = gwInfo.backendServers[0];
         gatewayPort = gwInfo.gatewayPort;
         adminPort = gwInfo.adminPort;
       })
@@ -129,7 +129,7 @@ describe('oauth2 authorization code grant type', () => {
 
   after(done => {
     gatewayProcess.kill();
-    backendServers[0].close(() => redirectServer.close(done));
+    backendServer.close(() => redirectServer.close(done));
   });
 
   it('authorizes a valid user', () => {

--- a/test/e2e/oauth2-authorization-code.js
+++ b/test/e2e/oauth2-authorization-code.js
@@ -21,7 +21,7 @@ describe('oauth2 authorization code grant type', () => {
 
   let gatewayProcess = null;
 
-  let gatewayPort, adminPort, redirectPort, redirectServer, backendServer;
+  let gatewayPort, adminPort, redirectPort, redirectServer, backendServers;
 
   before(function () {
     const gatewayConfig = {
@@ -81,7 +81,7 @@ describe('oauth2 authorization code grant type', () => {
       .then(gwInfo => {
         tempPath = gwInfo.dirInfo.configDirectoryPath;
         gatewayProcess = gwInfo.gatewayProcess;
-        backendServer = gwInfo.backendServer;
+        backendServers = gwInfo.backendServers;
         gatewayPort = gwInfo.gatewayPort;
         adminPort = gwInfo.adminPort;
       })
@@ -129,7 +129,7 @@ describe('oauth2 authorization code grant type', () => {
 
   after(done => {
     gatewayProcess.kill();
-    backendServer.close(() => redirectServer.close(done));
+    backendServers[0].close(() => redirectServer.close(done));
   });
 
   it('authorizes a valid user', () => {

--- a/test/e2e/proxy-through-proxy.test.js
+++ b/test/e2e/proxy-through-proxy.test.js
@@ -44,9 +44,9 @@ const cliHelper = require('../common/cli.helper');
           }
 
           process.env[envVariable] = `http://localhost:${server.address().port}`;
-          gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }).then(({ gatewayProcess, backendServer }) => {
+          gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }).then(({ gatewayProcess, backendServers }) => {
             gw = gatewayProcess;
-            bs = backendServer;
+            bs = backendServers;
             done();
           }).catch(done);
         });
@@ -57,7 +57,7 @@ const cliHelper = require('../common/cli.helper');
       delete process.env[envVariable];
       gw.kill();
       proxy.close();
-      srv.close(() => bs.close(done));
+      srv.close(() => bs[0].close(done));
     });
 
     it(`should respect ${envVariable} env var and send through proxy`, () => {

--- a/test/e2e/proxy-through-proxy.test.js
+++ b/test/e2e/proxy-through-proxy.test.js
@@ -66,7 +66,7 @@ const cliHelper = require('../common/cli.helper');
         .then((res) => {
           assert.ok(res.text);
           // we need to ensure that request went through proxy, not directly
-          assert.ok(proxiedUrls[`${gatewayConfig.serviceEndpoints.backend.url}/test`], 'Proxy was not called');
+          assert.ok(proxiedUrls[`${gatewayConfig.serviceEndpoints.backend.urls[0]}/test`], 'Proxy was not called');
         });
     });
   });

--- a/test/e2e/proxy-through-proxy.test.js
+++ b/test/e2e/proxy-through-proxy.test.js
@@ -46,7 +46,7 @@ const cliHelper = require('../common/cli.helper');
           process.env[envVariable] = `http://localhost:${server.address().port}`;
           gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }).then(({ gatewayProcess, backendServers }) => {
             gw = gatewayProcess;
-            bs = backendServers;
+            bs = backendServers[0];
             done();
           }).catch(done);
         });
@@ -57,7 +57,7 @@ const cliHelper = require('../common/cli.helper');
       delete process.env[envVariable];
       gw.kill();
       proxy.close();
-      srv.close(() => bs[0].close(done));
+      srv.close(() => bs.close(done));
     });
 
     it(`should respect ${envVariable} env var and send through proxy`, () => {

--- a/test/e2e/round-robin.test.js
+++ b/test/e2e/round-robin.test.js
@@ -1,139 +1,74 @@
-const { fork } = require('child_process');
+const should = require('should');
+const request = require('superagent');
 const fs = require('fs');
 const path = require('path');
 
-const should = require('should');
-const cpr = require('cpr');
-const request = require('superagent');
-const rimraf = require('rimraf');
-const tmp = require('tmp');
+const cliHelper = require('../common/cli.helper');
+const gwHelper = require('../common/gateway.helper');
+
 const yaml = require('js-yaml');
 
-const { generateBackendServer, findOpenPortNumbers } =
-  require('../common/server-helper');
-
-const baseConfigDirectory = path.join(__dirname, '..', 'fixtures', 'round-robin');
+const { generateBackendServer, findOpenPortNumbers } = require('../common/server-helper');
 
 describe('round-robin load @balancing @proxy', () => {
-  let testGatewayConfigPath = null;
-  let testGatewayConfigData = null;
-  let childProcess = null;
-  let gatewayPort = null;
-  let backendPorts = null;
+  let gatewayConfig;
+  let gatewayProcess;
+  const backendServers = [];
+  let gatewayPort;
 
-  before(function (done) {
-    this.timeout(10000);
-    tmp.dir((err, tempPath) => {
-      if (err) {
-        return done(err);
-      }
+  before(function () {
+    return findOpenPortNumbers(4).then(ports => {
+      gatewayConfig = yaml.load(fs.readFileSync(path.resolve('lib/config/gateway.config.yml')));
 
-      cpr(baseConfigDirectory, tempPath, (err, files) => {
-        if (err) {
-          return done(err);
-        }
+      gatewayPort = gatewayConfig.http.port = ports[0];
 
-        cpr(path.join(__dirname, '../../lib/config/models'), path.join(tempPath, 'models'), (err, files) => {
-          if (err) {
-            return done(err);
-          }
+      gatewayConfig.serviceEndpoints.backend.urls = [
+        `http://localhost:${ports[2]}`,
+        `http://localhost:${ports[3]}`
+      ];
 
-          testGatewayConfigPath = path.join(tempPath, 'gateway.config.yml');
-
-          findOpenPortNumbers(4).then(ports => {
-            fs.readFile(testGatewayConfigPath, (err, configData) => {
-              if (err) {
-                return done(err);
-              }
-
-              testGatewayConfigData = yaml.load(configData);
-
-              testGatewayConfigData.http.port = ports[0];
-              testGatewayConfigData.admin.port = ports[1];
-
-              testGatewayConfigData.serviceEndpoints.backend.urls = [
-                `http://localhost:${ports[2]}`,
-                `http://localhost:${ports[3]}`
-              ];
-
-              gatewayPort = ports[0];
-              backendPorts = [ports[2], ports[3]];
-
-              generateBackendServer(ports[2])
-                .then(() => {
-                  return generateBackendServer(ports[3]);
-                }).then(() => {
-                  ;
-                  fs.writeFile(testGatewayConfigPath,
-                    yaml.dump(testGatewayConfigData), (err) => {
-                      if (err) {
-                        return done(err);
-                      }
-
-                      const childEnv = Object.assign({}, process.env);
-                      childEnv.EG_CONFIG_DIR = tempPath;
-
-                      // Tests, by default have config watch disabled.
-                      // Need to remove this paramter in the child process.
-                      delete childEnv.EG_DISABLE_CONFIG_WATCH;
-
-                      const modulePath = path.join(__dirname, '..', '..', 'lib', 'index.js');
-                      childProcess = fork(modulePath, [], {
-                        cwd: tempPath,
-                        env: childEnv
-                      });
-
-                      childProcess.on('error', err => {
-                        return done(err);
-                      });
-
-                      // Not ideal, but we need to make sure the process is running.
-                      setTimeout(() => {
-                        request
-                          .get(`http://localhost:${gatewayPort}/not-found`)
-                          .end((err, res) => {
-                            should(err).not.be.undefined();
-                            should(res.clientError).not.be.undefined();
-                            should(res.statusCode).be.eql(404);
-                            done();
-                          });
-                      }, 5000);
-                    });
-                });
-            });
-          }).catch(done);
-        });
-      });
+      return cliHelper.bootstrapFolder()
+        .then(dirInfo => gwHelper.startGatewayInstance({ dirInfo, gatewayConfig }))
+        .then(gwInfo => {
+          gatewayProcess = gwInfo.gatewayProcess;
+          backendServers.push(gwInfo.backendServer);
+          gatewayPort = gwInfo.gatewayPort;
+          return generateBackendServer(ports[3]);
+        })
+        .then(server => backendServers.push(server));
     });
   });
 
-  after(done => {
-    childProcess.kill();
-    rimraf(testGatewayConfigPath, done);
+  after((done) => {
+    gatewayProcess.kill();
+    backendServers[0].close(() => backendServers[1].close(done));
   });
 
   it('proxies with a round-robin balancer', done => {
-    const [port1, port2] = backendPorts;
+    const messages = [];
+
     request
       .get(`http://localhost:${gatewayPort}/round-robin`)
       .end((err, res) => {
         if (err) return done(err);
         should(res.statusCode).be.eql(200);
-        should(res.text).be.eql(`Hello from port ${port1}`);
+        messages.push(res.text);
 
         request
           .get(`http://localhost:${gatewayPort}/round-robin`)
           .end((err, res) => {
             if (err) return done(err);
             should(res.statusCode).be.eql(200);
-            should(res.text).be.eql(`Hello from port ${port2}`);
+            messages.push(res.text);
 
             request
               .get(`http://localhost:${gatewayPort}/round-robin`)
               .end((err, res) => {
                 if (err) return done(err);
                 should(res.statusCode).be.eql(200);
-                should(res.text).be.eql(`Hello from port ${port1}`);
+                messages.push(res.text);
+                should(messages[0]).not.eql(messages[1]);
+                should(messages[0]).eql(messages[2]);
                 done();
               });
           });


### PR DESCRIPTION
Connect #579 
Connect #699 

This PR will cleanup the tests code a bit. In particular it will delete the big copy of `startGatewayInstance` that was put there because of particular needs of the oauth2 test files. I've modified the code so all the tests can use the same function.

Moreover, I've made sure to clean up all the resources — so these tests do finally close correctly once they're done.

This is really reducing our technical debt a lot.