### PR TITLE
Spell thrown error correctly on apps routes

### DIFF
--- a/lib/rest/routes/apps.js
+++ b/lib/rest/routes/apps.js
@@ -25,7 +25,7 @@ module.exports = function () {
       })
       .then(app => res.json(app))
       .catch(err => {
-        if (err.message.indexOf('exists') >= 0) {
+        if (err.message.indexOf('exist') >= 0) {
           res.status(409).send(err.message);
         } else {
           next(err);

--- a/test/rest-api/applications.js
+++ b/test/rest-api/applications.js
@@ -29,6 +29,15 @@ describe('REST: Applications', () => {
     );
   });
 
+  describe('Insert an application with an user that does not exist', () => {
+    it('should return an error on the second attemp', () =>
+      should(adminHelper.admin.apps.create('IDoNotExist', {
+        name: 'appy1',
+        redirectUri: 'http://localhost:3000/cb'
+      })).be.rejectedWith({ status: 409 })
+    );
+  });
+
   describe('Get an application by name', () => {
     it('should return the app if looking for it by name', () =>
       adminHelper.admin.apps.info('appy1').then((app) => {


### PR DESCRIPTION
Unfortunately some parts of our error handling is depending on the message content.

The lack of the final `s` was making our Admin API to return a 500 error message instead of a 409.