### PR TITLE
Make sure cli start URL does not end with a slash

### DIFF
--- a/bin/eg-generator.js
+++ b/bin/eg-generator.js
@@ -77,6 +77,12 @@ module.exports = class EgGenerator extends Generator {
       baseURL = `http://${hostname}:${port}`;
     }
 
+    /*
+      This bad hack is required because of the weird way superagent is managing urls. Hopefully this is not
+      going to be here forever — we'll replace the client with Axios hopefully.
+      Ref: https://github.com/ExpressGateway/express-gateway/issues/672
+    */
+
     if (baseURL.endsWith('/')) {
       baseURL = baseURL.substr(0, baseURL.length - 1);
     }

--- a/bin/eg-generator.js
+++ b/bin/eg-generator.js
@@ -77,6 +77,10 @@ module.exports = class EgGenerator extends Generator {
       baseURL = `http://${hostname}:${port}`;
     }
 
+    if (baseURL.endsWith('/')) {
+      baseURL = baseURL.substr(0, baseURL.length - 1);
+    }
+
     return baseURL;
   }
 


### PR DESCRIPTION
Connect #672 
Closes #672  

This PR will workaround a limitation in superagent, where its `prefix` plugin is breaking in case the CLI url ends with a slash.

This is temporary. The long term solution here would be to replace the client entirely with axios, which is better maintained as well as more complete by default.