### PR TITLE
Create and upload AMI on Express Gateway deploy — Connect LunchBadger/general#272

### DIFF
--- a/.circleci/aws.json
+++ b/.circleci/aws.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "aws_access_key": "",
-    "aws_secret_key": ""
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}"
   },
   "builders": [
     {

--- a/.circleci/aws.json
+++ b/.circleci/aws.json
@@ -1,0 +1,28 @@
+{
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": ""
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "region": "us-east-1",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "099720109477"
+        ],
+        "most_recent": true
+      },
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "express-gateway {{timestamp}}"
+    }
+  ]
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,12 @@ jobs:
 
   packer:
     docker:
-      - image: hashicorp/packer:light
+      - image: hashicorp/packer:full
     working_directory: ~/repo
 
     steps:
-      - run: packer validate example.json
+      - checkout
+      - run: packer validate ./.circleci/aws.json
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - checkout
-      - run: packer build ./.circleci/aws.json
+      - run: packer build ./.circleci/packer.json
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,12 +60,12 @@ jobs:
 
   packer:
     docker:
-      - image: hashicorp/packer:full
+      - image: hashicorp/packer:light
     working_directory: ~/repo
 
     steps:
       - checkout
-      - run: packer validate ./.circleci/aws.json
+      - run: packer build ./.circleci/aws.json
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: npm install
       - run: npm test
 
-  deploy:
+  release:
     docker:
       - image: circleci/node:8
     working_directory: ~/repo
@@ -57,6 +57,14 @@ jobs:
       - run: "docker tag expressgateway/express-gateway:${CIRCLE_TAG} expressgateway/express-gateway:latest"
       - run: "docker push expressgateway/express-gateway:${CIRCLE_TAG}"
       - run: "docker push expressgateway/express-gateway:latest"
+
+  packer:
+    docker:
+      - image: hashicorp/packer:light
+    working_directory: ~/repo
+
+    steps:
+      - run: packer validate example.json
 
 workflows:
   version: 2
@@ -78,7 +86,7 @@ workflows:
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
-      - deploy:
+      - release:
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
@@ -89,3 +97,7 @@ workflows:
             - node-8
             - node-8-real-redis
             - node-10
+      - packer:
+          filters:
+            tags:
+              only: /v\d+(\.\d+){2}/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,22 +70,13 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-6:
+      - node-6: &testingFilters
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
-      - node-8:
-          filters:
-            tags:
-              only: /v\d+(\.\d+){2}/
-      - node-10:
-          filters:
-            tags:
-              only: /v\d+(\.\d+){2}/
-      - node-8-real-redis:
-          filters:
-            tags:
-              only: /v\d+(\.\d+){2}/
+      - node-8: *testingFilters
+      - node-9: *testingFilters
+      - node-8-real-redis: *testingFilters
       - release:
           filters:
             tags:
@@ -101,3 +92,4 @@ workflows:
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
+      - packer: *testingFilters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
       - node-8: *testingFilters
       - node-9: *testingFilters
       - node-8-real-redis: *testingFilters
-      - release:
+      - release: &releaseFilters
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
@@ -89,8 +89,5 @@ workflows:
             - node-8
             - node-8-real-redis
             - node-10
-      - packer:
-          filters:
-            tags:
-              only: /v\d+(\.\d+){2}/
-      - packer: *testingFilters
+      - packer: *releaseFilters
+

--- a/.circleci/packer.json
+++ b/.circleci/packer.json
@@ -30,7 +30,7 @@
       },
       "instance_type": "t2.micro",
       "ssh_username": "ec2-user",
-      "ami_name": "express-gateway {{timestamp}}",
+      "ami_name": "express-gateway {{eg_version}}",
       "ami_description": "Amazon Linux with Express Gateway"
     }
   ],

--- a/.circleci/packer.json
+++ b/.circleci/packer.json
@@ -13,27 +13,35 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
+          "name": "amzn-ami*-ebs",
           "root-device-type": "ebs"
         },
         "owners": [
-          "099720109477"
+          "137112412989",
+          "591542846629",
+          "801119661308",
+          "102837901569",
+          "013907871322",
+          "206029621532",
+          "286198878708",
+          "443319210888"
         ],
         "most_recent": true
       },
       "instance_type": "t2.micro",
-      "ssh_username": "ubuntu",
-      "ami_name": "express-gateway {{timestamp}}"
+      "ssh_username": "ec2-user",
+      "ami_name": "express-gateway {{timestamp}}",
+      "ami_description": "Amazon Linux with Express Gateway"
     }
   ],
   "provisioners": [
     {
       "type": "shell",
       "inline": [
-        "curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -",
-        "sudo apt-get install -y nodejs",
-        "sudo apt-get install -y build-essential",
-        "npm install express-gateway"
+        "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash",
+        ". ~/.nvm/nvm.sh",
+        "nvm install --lts",
+        "npm install -g express-gateway"
       ]
     }
   ]

--- a/.circleci/packer.json
+++ b/.circleci/packer.json
@@ -1,14 +1,15 @@
 {
   "variables": {
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}"
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "eg_version": "{{env `CIRCLE_TAG`}}"
   },
   "builders": [
     {
       "type": "amazon-ebs",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
-      "region": "us-east-1",
+      "region": "us-west-2",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
@@ -23,6 +24,17 @@
       "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "express-gateway {{timestamp}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -",
+        "sudo apt-get install -y nodejs",
+        "sudo apt-get install -y build-essential",
+        "npm install express-gateway"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR will add another task for our CircleCI configuration in order to create and deploy an AMI image on AWS every time we'll release a new Express Gateway version.

I've self-commented this pull request in all the parts where I'm not sure I made the best choice — please provide me some feedback on that.