### PR TITLE
Add logger config

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,52 +1,63 @@
 const winston = require('winston');
 // TODO: rm LOG_LEVEL and LOG_LEVEL_xxx env vars and configure it system config;
 // system config will provide env vars support
+
+const colorize = process.env.LOG_COLORIZE !== 'false';
+const timestamp = process.env.LOG_TIMESTAMP === 'true';
+
 winston.loggers.add('EG:gateway', {
   console: {
     level: process.env.LOG_LEVEL_GATEWAY || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:gateway'
   }
 });
 winston.loggers.add('EG:policy', {
   console: {
     level: process.env.LOG_LEVEL_POLICY || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:policy'
   }
 });
 winston.loggers.add('EG:admin', {
   console: {
     level: process.env.LOG_LEVEL_ADMIN || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:admin'
   }
 });
 winston.loggers.add('EG:test', {
   console: {
     level: process.env.LOG_LEVEL_TEST || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:test'
   }
 });
 winston.loggers.add('EG:config', {
   console: {
     level: process.env.LOG_LEVEL_CONFIG || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:config'
   }
 });
 winston.loggers.add('EG:db', {
   console: {
     level: process.env.LOG_LEVEL_DB || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:db'
   }
 });
 winston.loggers.add('EG:plugins', {
   console: {
     level: process.env.LOG_LEVEL_PLUGINS || process.env.LOG_LEVEL || 'warn',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:plugins'
   }
 });

--- a/lib/policies/log/winston-logger.js
+++ b/lib/policies/log/winston-logger.js
@@ -2,10 +2,14 @@
 
 const winston = require('winston');
 
+const colorize = process.env.LOG_COLORIZE !== 'false';
+const timestamp = process.env.LOG_TIMESTAMP === 'true';
+
 winston.loggers.add('EG:log-policy', {
   console: {
     level: process.env.LOG_LEVEL_LOG_POLICY || process.env.LOG_LEVEL || 'error',
-    colorize: true,
+    colorize,
+    timestamp,
     label: 'EG:log-policy'
   }
 });


### PR DESCRIPTION
This pr support to solve the longer configuration for the current version.
Support the two configurations "timestamp" and "colorize" of winston consult transport.