### PR TITLE
Remove unused eslint plugin and use for real the one we need

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,13 @@ jobs:
 
     steps: &steps
       - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
       - run: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
       - run: npm test
 
   "node-8":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/node:6-browsers
     working_directory: ~/repo
 
-    steps:
+    steps: &steps
       - checkout
       - run: npm install
       - run: npm test
@@ -15,20 +15,14 @@ jobs:
       - image: circleci/node:8-browsers
     working_directory: ~/repo
 
-    steps:
-      - checkout
-      - run: npm install
-      - run: npm test
+    steps: *steps
 
   "node-10":
     docker:
       - image: circleci/node:10-browsers
     working_directory: ~/repo
 
-    steps:
-      - checkout
-      - run: npm install
-      - run: npm test
+    steps: *steps
 
   "node-8-real-redis":
     docker:
@@ -37,10 +31,7 @@ jobs:
     working_directory: ~/repo
     environment:
       - EG_DB_EMULATE: false
-    steps:
-      - checkout
-      - run: npm install
-      - run: npm test
+    steps: *steps
 
   release:
     docker:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 dist/
 coverage
 admin/node_modules
+bin/generators/gateway/templates/basic/server.js
+bin/generators/gateway/templates/getting-started/server.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,6 @@
     "node": true
   },
   "plugins": [
-    "markdown",
     "promise",
     "node"
   ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,16 @@
 {
-  "extends": "standard",
+  "extends": [
+    "standard",
+    "plugin:node/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
+  ],
   "env": {
     "es6": true,
     "node": true
   },
   "plugins": [
+    "import",
     "promise",
     "node"
   ],

--- a/bin/execution-scope.js
+++ b/bin/execution-scope.js
@@ -34,16 +34,10 @@ exports.executeInScope = env => {
     const childEnv = process.env;
     childEnv.EG_LOCAL_EXEC = true;
 
-    try {
-      execFileSync(localBin, process.argv.slice(2), {
-        cwd: env.cwd,
-        env: childEnv,
-        stdio: 'inherit'
-      });
-    } catch (err) {
-      process.exit(err.status);
-    }
-
-    process.exit();
+    execFileSync(localBin, process.argv.slice(2), {
+      cwd: env.cwd,
+      env: childEnv,
+      stdio: 'inherit'
+    });
   }
 };

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -12,7 +12,7 @@ try {
   ['system', 'gateway'].forEach(type => config.loadConfig(type));
 } catch (err) {
   log.error(err);
-  process.exit(1);
+  throw err;
 }
 
 module.exports = config;

--- a/migrations/1509389756097-model-to-jsonschema.js
+++ b/migrations/1509389756097-model-to-jsonschema.js
@@ -1,3 +1,5 @@
+/*eslint-disable */
+
 module.exports.up = function () {
   require('util.promisify/shim')();
   const log = require('migrate/lib/log');
@@ -8,7 +10,7 @@ module.exports.up = function () {
   const writeFile = util.promisify(fs.writeFile);
   const access = util.promisify(fs.access);
 
-  function copyFile (source, target) {
+  function copyFile(source, target) {
     const rd = fs.createReadStream(source);
     const wr = fs.createWriteStream(target);
     return new Promise(function (resolve, reject) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -564,12 +564,6 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
-    "bail": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -871,24 +865,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "character-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
-      "dev": true
-    },
-    "character-entities-legacy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
-      "dev": true
-    },
-    "character-reference-invalid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
-      "dev": true
-    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -1086,12 +1062,6 @@
         "request": "^2.81.0",
         "urlgrey": "0.4.4"
       }
-    },
-    "collapse-white-space": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
-      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2018,17 +1988,6 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
-      }
-    },
-    "eslint-plugin-markdown": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.0-beta.6.tgz",
-      "integrity": "sha1-2eYmZu6k52OH6F9QLfZoq9+9Q5U=",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.0.1",
-        "remark-parse": "^3.0.0",
-        "unified": "^6.1.2"
       }
     },
     "eslint-plugin-node": {
@@ -3443,22 +3402,6 @@
         }
       }
     },
-    "is-alphabetical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
-      "dev": true
-    },
-    "is-alphanumerical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
-      "dev": true,
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3521,12 +3464,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
-    "is-decimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
-      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3606,12 +3543,6 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-hexadecimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
-      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -3774,22 +3705,10 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
-    "is-whitespace-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-      "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
-      "dev": true
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-    },
-    "is-word-character": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
-      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
-      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -5107,12 +5026,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-escapes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-      "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
-      "dev": true
-    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -6335,20 +6248,6 @@
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
       "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
     },
-    "parse-entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
-      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
-      "dev": true,
-      "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -6927,30 +6826,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
-    },
-    "remark-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
-      "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
-      "dev": true,
-      "requires": {
-        "collapse-white-space": "^1.0.2",
-        "has": "^1.0.1",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -7646,12 +7521,6 @@
       "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
       "dev": true
     },
-    "state-toggle": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-      "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
-      "dev": true
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -8279,28 +8148,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": false,
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
-      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
-      "dev": true
-    },
-    "trough": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-      "integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ==",
       "dev": true
     },
     "tunnel-agent": {
@@ -8427,35 +8278,10 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
-    "unherit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
-      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
-      }
-    },
     "unicode": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/unicode/-/unicode-10.0.0.tgz",
       "integrity": "sha1-5dUcHbk7bHGguHngsMSvfm/faI4="
-    },
-    "unified": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
-      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
-      "dev": true,
-      "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-function": "^1.0.4",
-        "x-is-string": "^0.1.0"
-      }
     },
     "union-value": {
       "version": "1.0.0",
@@ -8487,36 +8313,6 @@
             "to-object-path": "^0.3.0"
           }
         }
-      }
-    },
-    "unist-util-is": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
-      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs=",
-      "dev": true
-    },
-    "unist-util-remove-position": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
-      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
-      "dev": true,
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "unist-util-stringify-position": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
-      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
-      "dev": true
-    },
-    "unist-util-visit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
-      "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
-      "dev": true,
-      "requires": {
-        "unist-util-is": "^2.1.1"
       }
     },
     "unpipe": {
@@ -8708,41 +8504,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vfile": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.4",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
-      },
-      "dependencies": {
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-          "dev": true
-        }
-      }
-    },
-    "vfile-location": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
-      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
-      "dev": true
-    },
-    "vfile-message": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
-      "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
-      "dev": true,
-      "requires": {
-        "unist-util-stringify-position": "^1.1.1"
-      }
-    },
     "vhost": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
@@ -8910,18 +8671,6 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
-    },
-    "x-is-function": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
-      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
-      "dev": true
-    },
-    "x-is-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
-      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "mocha-lcov-reporter": "1.3.0",
     "nyc": "^11.8.0",
     "puppeteer": "^1.4.0",
+    "rimraf": "^2.6.2",
     "should": "^13.2.1",
     "sinon": "^4.5.0",
     "supertest": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.11.0",
-    "eslint-plugin-markdown": "1.0.0-beta.6",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-standard": "^3.1.0",

--- a/scripts/json-schema-migration.js
+++ b/scripts/json-schema-migration.js
@@ -1,3 +1,4 @@
+/*eslint-disable */
 const migrate = require('migrate');
 const readline = require('readline');
 const path = require('path');


### PR DESCRIPTION
Connect #727 

This PR will remove the `markdown` plugin that was not used at all, as well as use for real the other plugins we have. (`import` and `node`)

New warnings and errors came out, and I resolved them.

Moreover, we have the `Promise` plugin that, if installed, throws over 300 warnings and errors that are worth fixing, but this is a bit time consuming. It's a todo though, for our next round of technical debt paying installment.

P.S: The reason for this PR is that with these plugins, if they would have been installed correctly, would have avoided the `puppeteer` "disaster" installed as a production dependency.