### PR TITLE
Introduce the body-modifier policy — connect LunchBadger/marketing#13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "6"
     - nodejs_version: "8"
-    - nodejs_version: "10"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/lib/eventBus.js
+++ b/lib/eventBus.js
@@ -1,5 +1,2 @@
-const {EventEmitter} = require('events');
-const logger = require('./logger').gateway;
-class EventBus extends EventEmitter {}
-logger.debug('Initiating Event Bus');
-module.exports = new EventBus();
+const { EventEmitter } = require('events');
+module.exports = new EventEmitter();

--- a/lib/policies/body-modifier/index.js
+++ b/lib/policies/body-modifier/index.js
@@ -47,7 +47,7 @@ module.exports = {
 
           if (params.request) {
             params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
-            params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
+            params.request.remove.forEach(removeParam => { delete req.body[removeParam]; });
 
             req.egContext.requestStream = new PassThrough();
             const bodyData = JSON.stringify(req.body);
@@ -62,7 +62,7 @@ module.exports = {
                 const body = JSON.parse(data);
 
                 params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
-                params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
+                params.response.remove.forEach(removeParam => { delete body[removeParam]; });
 
                 const bodyData = JSON.stringify(body);
 

--- a/lib/policies/body-modifier/index.js
+++ b/lib/policies/body-modifier/index.js
@@ -3,6 +3,13 @@ const { PassThrough } = require('stream');
 const jsonParser = require('express').json();
 const urlEncoded = require('express').urlencoded({ extended: false });
 
+const transformBody = (transformSpecs, egContext, body) => {
+  transformSpecs.add.forEach(addParam => { body[addParam.name] = egContext.run(addParam.value); });
+  transformSpecs.remove.forEach(removeParam => { delete body[removeParam]; });
+
+  return body;
+};
+
 module.exports = {
   schema: {
     $id: 'http://express-gateway.io/schemas/policies/body-modifier.json',
@@ -46,12 +53,9 @@ module.exports = {
           if (err) return next(err);
 
           if (params.request) {
-            params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
-            params.request.remove.forEach(removeParam => { delete req.body[removeParam]; });
-
-            req.egContext.requestStream = new PassThrough();
-            const bodyData = JSON.stringify(req.body);
+            const bodyData = JSON.stringify(transformBody(params.request, req.egContext, req.body));
             req.headers['content-length'] = Buffer.byteLength(bodyData);
+            req.egContext.requestStream = new PassThrough();
             req.egContext.requestStream.write(bodyData);
           }
 
@@ -59,11 +63,7 @@ module.exports = {
             const _write = res.write;
             res.write = (data) => {
               try {
-                const body = JSON.parse(data);
-
-                params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
-                params.response.remove.forEach(removeParam => { delete body[removeParam]; });
-
+                const body = transformBody(params.response, req.egContext, JSON.parse(data));
                 const bodyData = JSON.stringify(body);
 
                 res.setHeader('Content-Length', Buffer.byteLength(bodyData));

--- a/lib/policies/body-modifier/index.js
+++ b/lib/policies/body-modifier/index.js
@@ -5,7 +5,7 @@ const urlEncoded = require('express').urlencoded({ extended: false });
 
 module.exports = {
   schema: {
-    $id: 'http://express-gateway.io/schemas/policies/bodyModifier.json',
+    $id: 'http://express-gateway.io/schemas/policies/body-modifier.json',
     type: 'object',
     definitions: {
       addRemove: {
@@ -25,10 +25,7 @@ module.exports = {
           remove: {
             type: ['array'],
             items: {
-              type: 'object',
-              properties: {
-                name: { type: 'string' }
-              }
+              type: 'string'
             },
             default: []
           }

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -1,4 +1,5 @@
 const logger = require('../../logger').policy;
+const { PassThrough } = require('stream');
 const jsonParser = require('express').json();
 const urlEncoded = require('express').urlencoded({ extended: false });
 
@@ -40,44 +41,45 @@ module.exports = {
     }
   },
   policy: params => {
-    return (req, res, next) => jsonParser(req, res, (err) => {
-      if (err) return next(err);
-
-      urlEncoded(req, res, (err) => {
+    return (req, res, next) => {
+      jsonParser(req, res, (err) => {
         if (err) return next(err);
-        const _write = res.write;
 
-        if (params.request) {
-          req.egContext.transformFn = (proxyReq, req, res) => {
+        urlEncoded(req, res, (err) => {
+          if (err) return next(err);
+
+          if (params.request) {
             params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
             params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
 
+            req.egContext.requestStream = new PassThrough();
             const bodyData = JSON.stringify(req.body);
-            proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-            return proxyReq.write(bodyData);
-          };
-        }
+            req.headers['content-length'] = Buffer.byteLength(bodyData);
+            req.egContext.requestStream.write(bodyData);
+          }
 
-        if (params.response) {
-          res.write = (data) => {
-            try {
-              const body = JSON.parse(data);
+          if (params.response) {
+            const _write = res.write;
+            res.write = (data) => {
+              try {
+                const body = JSON.parse(data);
 
-              params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
-              params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
+                params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
+                params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
 
-              const bodyData = JSON.stringify(body);
+                const bodyData = JSON.stringify(body);
 
-              res.setHeader('Content-Length', Buffer.byteLength(bodyData));
-              _write.call(res, bodyData);
-            } catch (e) {
-              logger.warn(e);
-              _write.call(res, data);
-            }
-          };
-        }
-        next();
+                res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+                _write.call(res, bodyData);
+              } catch (e) {
+                logger.warn(e);
+                _write.call(res, data);
+              }
+            };
+          }
+          next();
+        });
       });
-    });
+    };
   }
 };

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -46,7 +46,7 @@ module.exports = {
         if (err) return next(err);
         const _write = res.write;
 
-        req.egContext.transformFn = function transformFn (proxyReq, req, res) {
+        req.egContext.transformFn = (proxyReq, req, res) => {
           if (req.body) {
             params.request.add.forEach(addParam => { req.body[addParam.name] = addParam.value; });
             params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
@@ -58,7 +58,7 @@ module.exports = {
           logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
         };
 
-        res.write = function (data) {
+        res.write = (data) => {
           try {
             const body = JSON.parse(data);
 

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -33,7 +33,7 @@ module.exports = {
           /*
            * This would be the section where I could change the body in the way I want
            */
-          body.fp = 'coracao';
+          body.jfp = 'coracao';
 
           const bodyData = JSON.stringify(body);
 

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -48,15 +48,12 @@ module.exports = {
 
         if (params.request) {
           req.egContext.transformFn = (proxyReq, req, res) => {
-            if (req.body) {
-              params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
-              params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
+            params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
+            params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
 
-              const bodyData = JSON.stringify(req.body);
-              proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-              return proxyReq.write(bodyData);
-            }
-            logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
+            const bodyData = JSON.stringify(req.body);
+            proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+            return proxyReq.write(bodyData);
           };
         }
 

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -18,24 +18,15 @@ module.exports = {
     });
 
     eventBus.on('proxyRes', (proxyRes, req, res) => {
-      if (res.body) {
-        const body = JSON.parse(res.body);
+      const _write = res.write;
 
-        // Change things
-
-        // CHange things
-        const bodyData = JSON.stringify(body);
-        return proxyRes.write(bodyData);
-      }
-
-      logger.warn('Unable to find any body response. Skipping the transformation step');
+      res.write = function (data) {
+        const body = JSON.parse(data);
+        body.fp = 'coracao';
+        _write.call(res, JSON.stringify(body));
+      };
     });
 
     return (req, res, next) => next();
-  },
-  schema: {
-    $id: 'http://express-gateway.io/schemas/policies/bodyModifier.json',
-    type: 'object',
-    properties: {}
   }
 };

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -1,31 +1,30 @@
-const eventBus = require('../../eventBus');
 const logger = require('../../logger').policy;
 const jsonParser = require('express').json();
 const urlEncoded = require('express').urlencoded({ extended: false });
 
 module.exports = {
   policy: params => {
-    eventBus.on('proxyReq', (proxyReq, req, res) => {
-      if (req.body) {
-        /*
-         * This would be the section where I could change the body in the way I want
-         */
-
-        req.body.fp = 'coracao';
-
-        const bodyData = JSON.stringify(req.body);
-        proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-        return proxyReq.write(bodyData);
-      }
-      logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
-    });
-
     return (req, res, next) => jsonParser(req, res, (err) => {
       if (err) return next(err);
 
       urlEncoded(req, res, (err) => {
         if (err) return next(err);
         const _write = res.write;
+
+        req.egContext.transformFn = function transformFn (proxyReq, req, res) {
+          if (req.body) {
+            /*
+             * This would be the section where I could change the body in the way I want
+             */
+
+            req.body.fp = 'coracao';
+
+            const bodyData = JSON.stringify(req.body);
+            proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+            return proxyReq.write(bodyData);
+          }
+          logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
+        };
 
         res.write = function (data) {
           const body = JSON.parse(data);

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -7,9 +7,11 @@ module.exports = {
   policy: params => {
     eventBus.on('proxyReq', (proxyReq, req, res) => {
       if (req.body) {
-        // Change the things
+        /*
+         * This would be the section where I could change the body in the way I want
+         */
 
-        // End Change the things
+        req.body.fp = 'coracao';
 
         const bodyData = JSON.stringify(req.body);
         proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
@@ -23,6 +25,10 @@ module.exports = {
 
       res.write = function (data) {
         const body = JSON.parse(data);
+
+        /*
+         * This would be the section where I could change the body in the way I want
+         */
         body.fp = 'coracao';
 
         const bodyData = JSON.stringify(body);

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -18,7 +18,8 @@ module.exports = {
                 name: { type: 'string' },
                 value: { type: 'string' }
               }
-            }
+            },
+            default: []
           },
           remove: {
             type: ['array'],
@@ -27,8 +28,8 @@ module.exports = {
               properties: {
                 name: { type: 'string' }
               }
-            }
-
+            },
+            default: []
           }
         }
       }

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -1,5 +1,7 @@
 const eventBus = require('../../eventBus');
 const logger = require('../../logger').policy;
+const jsonParser = require('express').json();
+const urlEncoded = require('express').urlencoded({ extended: false });
 
 module.exports = {
   policy: params => {
@@ -13,7 +15,6 @@ module.exports = {
         proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
         return proxyReq.write(bodyData);
       }
-
       logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
     });
 
@@ -31,6 +32,6 @@ module.exports = {
       };
     });
 
-    return (req, res, next) => next();
+    return (req, res, next) => jsonParser(req, res, () => { urlEncoded(req, res, next); });
   }
 };

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -48,7 +48,7 @@ module.exports = {
 
         req.egContext.transformFn = (proxyReq, req, res) => {
           if (req.body) {
-            params.request.add.forEach(addParam => { req.body[addParam.name] = addParam.value; });
+            params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
             params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
 
             const bodyData = JSON.stringify(req.body);
@@ -62,7 +62,7 @@ module.exports = {
           try {
             const body = JSON.parse(data);
 
-            params.response.add.forEach(addParam => { body[addParam.name] = addParam.value; });
+            params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
             params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
 
             const bodyData = JSON.stringify(body);

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -59,15 +59,20 @@ module.exports = {
         };
 
         res.write = function (data) {
-          const body = JSON.parse(data);
+          try {
+            const body = JSON.parse(data);
 
-          params.response.add.forEach(addParam => { body[addParam.name] = addParam.value; });
-          params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
+            params.response.add.forEach(addParam => { body[addParam.name] = addParam.value; });
+            params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
 
-          const bodyData = JSON.stringify(body);
+            const bodyData = JSON.stringify(body);
 
-          res.setHeader('Content-Length', Buffer.byteLength(bodyData));
-          _write.call(res, bodyData);
+            res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+            _write.call(res, bodyData);
+          } catch (e) {
+            logger.warn(e);
+            _write.call(res, data);
+          }
         };
         next();
       });

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -20,24 +20,28 @@ module.exports = {
       logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
     });
 
-    eventBus.on('proxyRes', (proxyRes, req, res) => {
-      const _write = res.write;
+    return (req, res, next) => jsonParser(req, res, (err) => {
+      if (err) return next(err);
 
-      res.write = function (data) {
-        const body = JSON.parse(data);
+      urlEncoded(req, res, (err) => {
+        if (err) return next(err);
+        const _write = res.write;
 
-        /*
-         * This would be the section where I could change the body in the way I want
-         */
-        body.fp = 'coracao';
+        res.write = function (data) {
+          const body = JSON.parse(data);
 
-        const bodyData = JSON.stringify(body);
+          /*
+           * This would be the section where I could change the body in the way I want
+           */
+          body.fp = 'coracao';
 
-        res.setHeader('Content-Length', Buffer.byteLength(bodyData));
-        _write.call(res, bodyData);
-      };
+          const bodyData = JSON.stringify(body);
+
+          res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+          _write.call(res, bodyData);
+        };
+        next();
+      });
     });
-
-    return (req, res, next) => jsonParser(req, res, () => { urlEncoded(req, res, next); });
   }
 };

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -3,6 +3,41 @@ const jsonParser = require('express').json();
 const urlEncoded = require('express').urlencoded({ extended: false });
 
 module.exports = {
+  schema: {
+    $id: 'http://express-gateway.io/schemas/policies/bodyModifier.json',
+    type: 'object',
+    definitions: {
+      addRemove: {
+        type: 'object',
+        properties: {
+          add: {
+            type: ['array'],
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                value: { type: 'string' }
+              }
+            }
+          },
+          remove: {
+            type: ['array'],
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' }
+              }
+            }
+
+          }
+        }
+      }
+    },
+    properties: {
+      request: { '$ref': '#/definitions/addRemove' },
+      response: { '$ref': '#/definitions/addRemove' }
+    }
+  },
   policy: params => {
     return (req, res, next) => jsonParser(req, res, (err) => {
       if (err) return next(err);

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -46,34 +46,38 @@ module.exports = {
         if (err) return next(err);
         const _write = res.write;
 
-        req.egContext.transformFn = (proxyReq, req, res) => {
-          if (req.body) {
-            params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
-            params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
+        if (params.request) {
+          req.egContext.transformFn = (proxyReq, req, res) => {
+            if (req.body) {
+              params.request.add.forEach(addParam => { req.body[addParam.name] = req.egContext.run(addParam.value); });
+              params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
 
-            const bodyData = JSON.stringify(req.body);
-            proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-            return proxyReq.write(bodyData);
-          }
-          logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
-        };
+              const bodyData = JSON.stringify(req.body);
+              proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+              return proxyReq.write(bodyData);
+            }
+            logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
+          };
+        }
 
-        res.write = (data) => {
-          try {
-            const body = JSON.parse(data);
+        if (params.response) {
+          res.write = (data) => {
+            try {
+              const body = JSON.parse(data);
 
-            params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
-            params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
+              params.response.add.forEach(addParam => { body[addParam.name] = req.egContext.run(addParam.value); });
+              params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
 
-            const bodyData = JSON.stringify(body);
+              const bodyData = JSON.stringify(body);
 
-            res.setHeader('Content-Length', Buffer.byteLength(bodyData));
-            _write.call(res, bodyData);
-          } catch (e) {
-            logger.warn(e);
-            _write.call(res, data);
-          }
-        };
+              res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+              _write.call(res, bodyData);
+            } catch (e) {
+              logger.warn(e);
+              _write.call(res, data);
+            }
+          };
+        }
         next();
       });
     });

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -1,0 +1,41 @@
+const eventBus = require('../../eventBus');
+const logger = require('../../logger').policy;
+
+module.exports = {
+  policy: params => {
+    eventBus.on('proxyReq', (proxyReq, req, res) => {
+      if (req.body) {
+        // Change the things
+
+        // End Change the things
+
+        const bodyData = JSON.stringify(req.body);
+        proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+        return proxyReq.write(bodyData);
+      }
+
+      logger.warn('Unable to find a parsed body request. You might want to put the body parser policy first. Skipping the transform action');
+    });
+
+    eventBus.on('proxyRes', (proxyRes, req, res) => {
+      if (res.body) {
+        const body = JSON.parse(res.body);
+
+        // Change things
+
+        // CHange things
+        const bodyData = JSON.stringify(body);
+        return proxyRes.write(bodyData);
+      }
+
+      logger.warn('Unable to find any body response. Skipping the transformation step');
+    });
+
+    return (req, res, next) => next();
+  },
+  schema: {
+    $id: 'http://express-gateway.io/schemas/policies/bodyModifier.json',
+    type: 'object',
+    properties: {}
+  }
+};

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -23,7 +23,11 @@ module.exports = {
       res.write = function (data) {
         const body = JSON.parse(data);
         body.fp = 'coracao';
-        _write.call(res, JSON.stringify(body));
+
+        const bodyData = JSON.stringify(body);
+
+        res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+        _write.call(res, bodyData);
       };
     });
 

--- a/lib/policies/bodyModifier/index.js
+++ b/lib/policies/bodyModifier/index.js
@@ -13,11 +13,8 @@ module.exports = {
 
         req.egContext.transformFn = function transformFn (proxyReq, req, res) {
           if (req.body) {
-            /*
-             * This would be the section where I could change the body in the way I want
-             */
-
-            req.body.fp = 'coracao';
+            params.request.add.forEach(addParam => { req.body[addParam.name] = addParam.value; });
+            params.request.remove.forEach(removeParam => { delete req.body[removeParam.name]; });
 
             const bodyData = JSON.stringify(req.body);
             proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
@@ -29,10 +26,8 @@ module.exports = {
         res.write = function (data) {
           const body = JSON.parse(data);
 
-          /*
-           * This would be the section where I could change the body in the way I want
-           */
-          body.jfp = 'coracao';
+          params.response.add.forEach(addParam => { body[addParam.name] = addParam.value; });
+          params.response.remove.forEach(removeParam => { delete body[removeParam.name]; });
 
           const bodyData = JSON.stringify(body);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -4,7 +4,6 @@ const httpProxy = require('http-proxy');
 const ProxyAgent = require('proxy-agent');
 const logger = require('../../logger').policy;
 const strategies = require('./strategies');
-const eventBus = require('../../eventBus');
 
 const createStrategy = (strategy, proxyOptions, endpointUrls) => {
   const Strategy = strategies[strategy];
@@ -65,8 +64,6 @@ module.exports = function (params, config) {
     }
   });
 
-  proxy.on('proxyReq', (proxyReq, req, res) => eventBus.emit('proxyReq', proxyReq, req, res));
-
   let strategy;
   let urls;
 
@@ -81,6 +78,9 @@ module.exports = function (params, config) {
   const balancer = createStrategy(strategy, proxyOptions, urls);
 
   return function proxyHandler (req, res) {
+    if (req.egContext.transformFn) {
+      proxy.on('proxyReq', req.egContext.transformFn);
+    }
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -65,7 +65,7 @@ module.exports = function (params, config) {
     }
   });
 
-  ['proxyReq', 'proxyRes'].forEach(event => proxy.on(event, (proxyObj, req, res) => eventBus.emit(event, proxyObj, req, res)));
+  proxy.on('proxyReq', (proxyReq, req, res) => eventBus.emit('proxyReq', proxyReq, req, res));
 
   let strategy;
   let urls;

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -79,7 +79,7 @@ module.exports = function (params, config) {
 
   return function proxyHandler (req, res) {
     if (req.egContext.transformFn) {
-      proxy.on('proxyReq', req.egContext.transformFn);
+      proxy.once('proxyReq', req.egContext.transformFn);
     }
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -4,6 +4,7 @@ const httpProxy = require('http-proxy');
 const ProxyAgent = require('proxy-agent');
 const logger = require('../../logger').policy;
 const strategies = require('./strategies');
+const eventBus = require('../../eventBus');
 
 const createStrategy = (strategy, proxyOptions, endpointUrls) => {
   const Strategy = strategies[strategy];
@@ -63,6 +64,8 @@ module.exports = function (params, config) {
       res.end();
     }
   });
+
+  ['proxyReq', 'proxyRes'].forEach(event => proxy.on(event, (proxyObj, req, res) => eventBus.emit(event, proxyObj, req, res)));
 
   let strategy;
   let urls;

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -78,15 +78,12 @@ module.exports = function (params, config) {
   const balancer = createStrategy(strategy, proxyOptions, urls);
 
   return function proxyHandler (req, res) {
-    if (req.egContext.transformFn) {
-      proxy.once('proxyReq', req.egContext.transformFn);
-    }
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 
-    proxy.web(req, res, { target, headers });
+    proxy.web(req, res, { target, headers, buffer: req.egContext.requestStream });
   };
 
   // multiple urls will load balance, defaulting to round-robin

--- a/test/policies/body-modifier/body-modifier.test.js
+++ b/test/policies/body-modifier/body-modifier.test.js
@@ -60,8 +60,8 @@ const gatewayConfig = (backendPort) => ({
 
 describe('body modifier Policy', () => {
   before(() => {
-    return serverHelper.findOpenPortNumbers(2)
-      .then(([port, backendPort]) => {
+    return serverHelper.findOpenPortNumbers(1)
+      .then(([backendPort]) => {
         config.gatewayConfig = gatewayConfig(backendPort);
         const app = express();
 
@@ -81,7 +81,7 @@ describe('body modifier Policy', () => {
       .then(() => testHelper.setup()).then(({ app }) => { gateway = app; });
   });
 
-  it('should remove some properties and add some others', () =>
+  it('should remove some properties and add some others when sending content', () =>
     request(gateway)
       .post('/')
       .send({ name: 'Clark', surname: 'Kent' })

--- a/test/policies/body-modifier/body-modifier.test.js
+++ b/test/policies/body-modifier/body-modifier.test.js
@@ -1,0 +1,99 @@
+const request = require('supertest');
+const express = require('express');
+const should = require('should');
+const serverHelper = require('../../common/server-helper');
+const config = require('../../../lib/config');
+const testHelper = require('../../common/routing.helper')();
+
+const originalGatewayConfig = JSON.parse(JSON.stringify(config.gatewayConfig));
+const originalSystemConfig = JSON.parse(JSON.stringify(config.systemConfig));
+
+let gateway;
+let introspectApp;
+
+const gatewayConfig = (backendPort) => ({
+  http: { port: 0 },
+  serviceEndpoints: {
+    backend: {
+      url: `http://localhost:${backendPort}`
+    }
+  },
+  apiEndpoints: {
+    authorizedEndpoint: {
+      host: '*'
+    }
+  },
+  policies: ['body-modifier', 'proxy'],
+  pipelines: {
+    pipeline1: {
+      apiEndpoints: ['authorizedEndpoint'],
+      policies: [
+        {
+          'body-modifier': {
+            action: {
+              request: {
+                add: [
+                  {
+                    name: 'fullname',
+                    value: 'req.body.name + \' \' + req.body.surname'
+                  }
+                ],
+                remove: ['name', 'surname']
+              },
+              response: {
+                add: [
+                  {
+                    name: 'createdBy',
+                    value: '\'Clark Kent\''
+                  }
+                ],
+                remove: ['uselessParam']
+              }
+            }
+          }
+        },
+        { proxy: [{ action: { serviceEndpoint: 'backend' } }] }
+      ]
+    }
+  }
+});
+
+describe('body modifier Policy', () => {
+  before(() => {
+    return serverHelper.findOpenPortNumbers(2)
+      .then(([port, backendPort]) => {
+        config.gatewayConfig = gatewayConfig(backendPort);
+        const app = express();
+
+        app.post('*', express.json(), (req, res) => {
+          should(req.body).have.property('fullname');
+          should(req.body).not.have.properties(['name', 'surname']);
+          res.json({ customerId: 123456789, uselessParam: 10 });
+        });
+
+        return new Promise((resolve, reject) => {
+          introspectApp = app.listen(backendPort, (err) => {
+            if (err) return reject(err);
+            resolve();
+          });
+        });
+      })
+      .then(() => testHelper.setup()).then(({ app }) => { gateway = app; });
+  });
+
+  it('should remove some properties and add some others', () =>
+    request(gateway)
+      .post('/')
+      .send({ name: 'Clark', surname: 'Kent' })
+      .expect(200, {
+        customerId: '123456789',
+        createdBy: 'Clark Kent'
+      })
+  );
+
+  after('cleanup', (done) => {
+    config.systemConfig = originalSystemConfig;
+    config.gatewayConfig = originalGatewayConfig;
+    gateway.close(() => introspectApp.close(done));
+  });
+});


### PR DESCRIPTION
The following PR is a proposal to have a request/response body modifier in the core.

This feature has been required by multiple users and it should help a lot people to move forward and adopting the gateway.


## Example usage

```yaml
body-modifier:
  action:
    request:
      add:
      - name: fullname
        value: req.body.name + ' ' + req.body.surname
      remove:
      - name
      - surname
    response:
      add:
      - name: createdBy
        value: req.user.id
      remove:
      - uselessParam
```

You can see that basically you have a `add` and `remove` property. The first one is an array of object containing `name` and `value` —  the value is evaluated as a code property, so you can grab data from the `req` object.

The remove property is a simple string array that'll be simply removed. 

## Outstanding issues
- [x] Tests
- [ ] The current code is trying to first parse the body as json, then as form/url encoded. I'm not too sure if we should go with this brute force approach or maybe set this as a configuration property. You could tell in the policy to parse the body as JSON or as UrlEnconded and restream it as something else.
- [ ] Is `body-modifier` a meaningful name?
- [x] Request/Response transformation logic is the same. Try to DRY it.
- [ ] Maybe we can use destructuring and `object.assign` instead of `delete`?