### PR TITLE
Fix plugin schema validation.

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -33,18 +33,11 @@ module.exports.load = function ({ config }) {
       }
 
       // register schema and validate settings
-      let validate;
-      try {
-        validate = schemas.register('plugin', pluginName, plugin.schema);
-      } catch (e) {
-        logger.error(`Wrong schema definition for ${pluginName}`, e);
-      }
-
-      if (validate !== undefined) {
-        const {isValid, error} = validate(settings);
-        if (!isValid) {
-          throw new Error('Failed to validate settings: ' + error);
-        }
+      const validate = schemas.register('plugin', pluginName, plugin.schema);
+      const { isValid, error } = validate(settings);
+      if (!isValid) {
+        // Stop loading plugin.
+        throw new Error(`Failed to validate settings: ${error}`);
       }
 
       const services = require('./services');

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -33,10 +33,18 @@ module.exports.load = function ({ config }) {
       }
 
       // register schema and validate settings
+      let validate;
       try {
-        schemas.register('plugin', pluginName, plugin.schema)(settings);
+        validate = schemas.register('plugin', pluginName, plugin.schema);
       } catch (e) {
         logger.error(`Wrong schema definition for ${pluginName}`, e);
+      }
+
+      if (validate !== undefined) {
+        const {isValid, error} = validate(settings);
+        if (!isValid) {
+          throw new Error('Failed to validate settings: ' + error);
+        }
       }
 
       const services = require('./services');

--- a/test/plugins/schema.test.js
+++ b/test/plugins/schema.test.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const should = require('should');
+
+const pluginsLoader = require('../../lib/plugins');
+
+// Caching fixture plugin, but redefining its properties for testing plugin load.
+const pluginName = 'express-gateway-plugin-test';
+const pluginDirectory = path.join(__dirname, '../fixtures', pluginName);
+const testPlugin = require(pluginDirectory);
+testPlugin.schema = {
+  '$id': `http://express-gateway.io/schemas/plugin/${pluginName}.json`,
+  'required': ['schema-test-param']
+};
+testPlugin.init = (pluginContext) => {
+  pluginContext.registerPolicy('schema-test-policy');
+};
+
+describe('Plugin schema validation on load', () => {
+  it('fails loading when parameter undefined', () => {
+    const missingParameterConfig = {
+      'config': {
+        'systemConfig': {
+          'plugins': {
+            'test': {
+              'package': pluginDirectory
+            }
+          }
+        }
+      }
+    };
+
+    const loadedPlugins = pluginsLoader.load(missingParameterConfig);
+    should(loadedPlugins).a.property('policies').be.empty();
+  });
+
+  it('loads plugin and registers policy successfully', () => {
+    const config = {
+      'config': {
+        'systemConfig': {
+          'plugins': {
+            'test': {
+              'package': pluginDirectory,
+              'schema-test-param': 'defined'
+            }
+          }
+        }
+      }
+    };
+
+    const loadedPlugins = pluginsLoader.load(config);
+    should(loadedPlugins).have.a.property('policies', ['schema-test-policy']);
+  });
+});

--- a/test/plugins/schema.test.js
+++ b/test/plugins/schema.test.js
@@ -7,10 +7,12 @@ const pluginsLoader = require('../../lib/plugins');
 const pluginName = 'express-gateway-plugin-test';
 const pluginDirectory = path.join(__dirname, '../fixtures', pluginName);
 const testPlugin = require(pluginDirectory);
+
 testPlugin.schema = {
   '$id': `http://express-gateway.io/schemas/plugin/${pluginName}.json`,
   'required': ['schema-test-param']
 };
+
 testPlugin.init = (pluginContext) => {
   pluginContext.registerPolicy('schema-test-policy');
 };
@@ -30,7 +32,7 @@ describe('Plugin schema validation on load', () => {
     };
 
     const loadedPlugins = pluginsLoader.load(missingParameterConfig);
-    should(loadedPlugins).a.property('policies').be.empty();
+    should(loadedPlugins).have.property('policies').empty();
   });
 
   it('loads plugin and registers policy successfully', () => {
@@ -48,6 +50,6 @@ describe('Plugin schema validation on load', () => {
     };
 
     const loadedPlugins = pluginsLoader.load(config);
-    should(loadedPlugins).have.a.property('policies', ['schema-test-policy']);
+    should(loadedPlugins).have.property('policies', ['schema-test-policy']);
   });
 });


### PR DESCRIPTION
Will throw an error ("Failed to validate settings") in case if settings validation fail. Therefore will stop loading of current plugin.
Will pass schema validation in case of malformed schema itself.