### PR TITLE
Provide refresh tokens for JWT

### DIFF
--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -123,7 +123,7 @@ server.exchange(oauth2orize.exchange.code((consumer, code, redirectUri, done) =>
       if (config.systemConfig.accessTokens.tokenType === 'jwt') {
         return tokenService
           .createJWT({ consumerId: consumer.id, scopes: codeObj.scopes })
-          .then(res => Promise.all([res, tokenService.save({ consumerId: consumer.id }, { refreshTokenOnly: true })]))
+          .then(res => Promise.all([res, tokenService.save({ consumerId: consumer.id, scopes: codeObj.scopes }, { refreshTokenOnly: true })]))
           .then(([res, token]) => done(null, res, token.refresh_token, { expires_in: expiresIn }))
           .catch(done);
       }
@@ -165,7 +165,7 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
       if (config.systemConfig.accessTokens.tokenType === 'jwt') {
         return tokenService
           .createJWT({ consumerId: consumer.id, scopes })
-          .then(res => Promise.all([res, tokenService.save({ consumerId: consumer.id }, { refreshTokenOnly: true })]))
+          .then(res => Promise.all([res, tokenService.save({ consumerId: consumer.id, scopes }, { refreshTokenOnly: true })]))
           .then(([res, token]) => done(null, res, token.refresh_token, { expires_in: expiresIn }))
           .catch(done);
       }

--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -123,7 +123,8 @@ server.exchange(oauth2orize.exchange.code((consumer, code, redirectUri, done) =>
       if (config.systemConfig.accessTokens.tokenType === 'jwt') {
         return tokenService
           .createJWT({ consumerId: consumer.id, scopes: codeObj.scopes })
-          .then(res => done(null, res))
+          .then(res => Promise.all([res, tokenService.save({ consumerId: consumer.id }, { refreshTokenOnly: true })]))
+          .then(([res, token]) => done(null, res, token.refresh_token, { expires_in: expiresIn }))
           .catch(done);
       }
 
@@ -164,7 +165,8 @@ server.exchange(oauth2orize.exchange.password((consumer, username, password, sco
       if (config.systemConfig.accessTokens.tokenType === 'jwt') {
         return tokenService
           .createJWT({ consumerId: consumer.id, scopes })
-          .then(res => done(null, res))
+          .then(res => Promise.all([res, tokenService.save({ consumerId: consumer.id }, { refreshTokenOnly: true })]))
+          .then(([res, token]) => done(null, res, token.refresh_token, { expires_in: expiresIn }))
           .catch(done);
       }
 
@@ -229,6 +231,13 @@ server.exchange(oauth2orize.exchange.refreshToken(function (consumer, refreshTok
     .then(tokenObj => {
       if (!tokenObj) {
         return done(null, false);
+      }
+
+      if (config.systemConfig.accessTokens.tokenType === 'jwt') {
+        return tokenService
+          .createJWT({ consumerId: consumer.id, scopes: tokenObj.scopes })
+          .then(res => done(null, res))
+          .catch(done);
       }
 
       return tokenService.findOrSave(tokenObj)

--- a/lib/services/tokens/token.service.js
+++ b/lib/services/tokens/token.service.js
@@ -17,9 +17,8 @@ function getSecret () {
 
 const s = {};
 
-s.save = function (tokenObj, options) {
+s.save = function (tokenObj, options = {}) {
   let rt;
-  options = options || {};
 
   if (!tokenObj.consumerId) {
     return Promise.reject(new Error('invalid token args'));
@@ -51,9 +50,7 @@ s.save = function (tokenObj, options) {
     });
 };
 
-s.findOrSave = function (tokenObj, options) {
-  options = options || {};
-
+s.findOrSave = function (tokenObj, options = {}) {
   return this.find(tokenObj, options)
     .then(tokens => {
       if (tokens.access_token) {
@@ -78,8 +75,7 @@ s.findOrSave = function (tokenObj, options) {
     });
 };
 
-s.find = function (tokenObj, options) {
-  options = options || {};
+s.find = function (tokenObj, options = {}) {
   const tokenQueryCriteria = Object.assign({}, tokenObj);
 
   if (tokenQueryCriteria.scopes && Array.isArray(tokenQueryCriteria.scopes)) {
@@ -101,8 +97,7 @@ s.find = function (tokenObj, options) {
     });
 };
 
-s.get = function (_token, options) {
-  options = options || {};
+s.get = function (_token, options = {}) {
   const tokenId = _token.split('|')[0];
 
   return tokenDao.get(tokenId, options)

--- a/test/policies/oauth/jwt-token.js
+++ b/test/policies/oauth/jwt-token.js
@@ -153,6 +153,20 @@ describe('oAuth2 policy', () => {
       jwtTokenChecks(() => _response);
     });
 
+    describe('should do the same with client credential flow', () => {
+      before(() => request(gateway)
+        .post('/oauth2/token')
+        .send({
+          grant_type: 'client_credentials',
+          client_id: appCredential.id,
+          client_secret: appCredential.secret,
+          scope: ['read', 'write'].join(' ')
+        }).expect(200).then((response) => { _response = response.body; })
+      );
+
+      jwtTokenChecks(() => _response);
+    });
+
     after('cleanup', (done) => {
       config.systemConfig = originalSystemConfig;
       config.gatewayConfig = originalGatewayConfig;


### PR DESCRIPTION
Connect #744
Closes #744

This Pull Request provides refresh tokens support for JWT tokens. Previously, it was available for opaque tokens only.

This has been done leveraging the `tokenService.save` function that fortunately for us allows creating refresh tokens only.

I've also updated the tests to check that the refresh token is returned as well that using it a new token gets issued.

P.S: These two flows should be unified somehow. Right now, they're just two `if` paths that are a little bit hard to maintain.

It was a mistake to not bake JWT logic in the `save*` function. I do not remember why I didn't do it. Maybe I found it too hard/too much refactor to do?