### PR TITLE
Make the CLI follow the nextKey for app and users

### DIFF
--- a/admin/apps.js
+++ b/admin/apps.js
@@ -42,7 +42,7 @@ module.exports = function (client) {
         if (params.all && res.body.nextKey !== 0) {
           return client
             .get(baseUrl)
-            .query(Object.assign({}, params, { start: res.body.nextKey }))
+            .query({ start: res.body.nextKey, count: params.count })
             .then(fetchNext);
         }
         return { apps: results, nextKey: res.body.nextKey };

--- a/admin/apps.js
+++ b/admin/apps.js
@@ -45,7 +45,7 @@ module.exports = function (client) {
             .query(Object.assign({}, params, { start: res.body.nextKey }))
             .then(fetchNext);
         }
-        return { apps: results };
+        return { apps: results, nextKey: res.body.nextKey };
       };
 
       return client

--- a/admin/apps.js
+++ b/admin/apps.js
@@ -34,12 +34,12 @@ module.exports = function (client) {
         .then(res => res.body);
     },
 
-    list (params) {
+    list (params = {}) {
       let results = [];
 
       const fetchNext = (res) => {
         results = results.concat(res.body.apps);
-        if (res.body.nextKey !== 0) {
+        if (params.all && res.body.nextKey !== 0) {
           return client
             .get(baseUrl)
             .query(Object.assign({}, params, { start: res.body.nextKey }))

--- a/admin/apps.js
+++ b/admin/apps.js
@@ -35,10 +35,23 @@ module.exports = function (client) {
     },
 
     list (params) {
+      let results = [];
+
+      const fetchNext = (res) => {
+        results = results.concat(res.body.apps);
+        if (res.body.nextKey !== 0) {
+          return client
+            .get(baseUrl)
+            .query(Object.assign({}, params, { start: res.body.nextKey }))
+            .then(fetchNext);
+        }
+        return { apps: results };
+      };
+
       return client
         .get(baseUrl)
         .query(params)
-        .then(res => res.body);
+        .then(fetchNext);
     },
 
     remove (id) {

--- a/admin/users.js
+++ b/admin/users.js
@@ -35,13 +35,13 @@ module.exports = function (client) {
     list (params) {
       let results = [];
 
-      const fetchNext = (res, queryParams = {}) => {
+      const fetchNext = (res) => {
         results = results.concat(res.body.users);
         if (res.body.nextKey !== 0) {
           return client
             .get(baseUrl)
-            .query(Object.assign(queryParams, { start: res.body.nextKey }))
-            .then(res => fetchNext(res, queryParams));
+            .query(Object.assign({}, params, { start: res.body.nextKey }))
+            .then(fetchNext);
         }
         return { users: results };
       };
@@ -49,7 +49,7 @@ module.exports = function (client) {
       return client
         .get(baseUrl)
         .query(params)
-        .then(res => fetchNext(res, params));
+        .then(fetchNext);
     },
 
     remove (id) {

--- a/admin/users.js
+++ b/admin/users.js
@@ -33,12 +33,23 @@ module.exports = function (client) {
         .then(res => res.body);
     },
     list (params) {
+      let results = [];
+
+      const fetchNext = (res, queryParams = {}) => {
+        results = results.concat(res.body.users);
+        if (res.body.nextKey !== 0) {
+          return client
+            .get(baseUrl)
+            .query(Object.assign(queryParams, { start: res.body.nextKey }))
+            .then(res => fetchNext(res, queryParams));
+        }
+        return { users: results };
+      };
+
       return client
         .get(baseUrl)
         .query(params)
-        .then(res => {
-          return res.body;
-        });
+        .then(res => fetchNext(res, params));
     },
 
     remove (id) {

--- a/admin/users.js
+++ b/admin/users.js
@@ -40,7 +40,7 @@ module.exports = function (client) {
         if (params.all && res.body.nextKey !== 0) {
           return client
             .get(baseUrl)
-            .query(Object.assign({}, params, { start: res.body.nextKey }))
+            .query({ start: res.body.nextKey, count: params.count })
             .then(fetchNext);
         }
         return { users: results, nextKey: res.body.nextKey };

--- a/admin/users.js
+++ b/admin/users.js
@@ -32,12 +32,12 @@ module.exports = function (client) {
         .get(`${baseUrl}${encodeURIComponent(id)}`)
         .then(res => res.body);
     },
-    list (params) {
+    list (params = {}) {
       let results = [];
 
       const fetchNext = (res) => {
         results = results.concat(res.body.users);
-        if (res.body.nextKey !== 0) {
+        if (params.all && res.body.nextKey !== 0) {
           return client
             .get(baseUrl)
             .query(Object.assign({}, params, { start: res.body.nextKey }))

--- a/admin/users.js
+++ b/admin/users.js
@@ -43,7 +43,7 @@ module.exports = function (client) {
             .query(Object.assign({}, params, { start: res.body.nextKey }))
             .then(fetchNext);
         }
-        return { users: results };
+        return { users: results, nextKey: res.body.nextKey };
       };
 
       return client

--- a/bin/generators/apps/list.js
+++ b/bin/generators/apps/list.js
@@ -10,7 +10,7 @@ module.exports = class extends eg.Generator {
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
-          .boolean('a').alias('a', 'all').describe('a', 'Show all the elements instead of stopping to the fist page')
+          .boolean('a').alias('a', 'all').describe('a', 'List all the apps instead of stopping to the fist page')
           .example(`$0 ${process.argv[2]} list`)
     });
   }

--- a/bin/generators/apps/list.js
+++ b/bin/generators/apps/list.js
@@ -10,12 +10,13 @@ module.exports = class extends eg.Generator {
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
+          .boolean('a').alias('a', 'all').describe('a', 'Show all the elements instead of stopping to the fist page')
           .example(`$0 ${process.argv[2]} list`)
     });
   }
 
   prompting () {
-    return this.admin.apps.list()
+    return this.admin.apps.list({ all: this.argv.a })
       .then(data => {
         const apps = data.apps;
         if (!apps || !apps.length) {

--- a/bin/generators/users/list.js
+++ b/bin/generators/users/list.js
@@ -10,11 +10,12 @@ module.exports = class extends eg.Generator {
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
+          .boolean('a').alias('a', 'all').describe('a', 'Show all the elements instead of stopping to the fist page')
           .example(`$0 ${process.argv[2]} list`)
     });
   }
   prompting () {
-    return this.admin.users.list()
+    return this.admin.users.list({ all: this.argv.a })
       .then(data => {
         const users = data.users;
         if (!users || !users.length) {

--- a/bin/generators/users/list.js
+++ b/bin/generators/users/list.js
@@ -10,7 +10,7 @@ module.exports = class extends eg.Generator {
       builder: yargs =>
         yargs
           .usage(`Usage: $0 ${process.argv[2]} list [options]`)
-          .boolean('a').alias('a', 'all').describe('a', 'Show all the elements instead of stopping to the fist page')
+          .boolean('a').alias('a', 'all').describe('a', 'List all the users instead of stopping to the fist page')
           .example(`$0 ${process.argv[2]} list`)
     });
   }

--- a/lib/rest/routes/users.js
+++ b/lib/rest/routes/users.js
@@ -5,11 +5,7 @@ const logger = require('../../logger').admin;
 module.exports = function () {
   const router = express.Router();
 
-  router.get('/', function (req, res, next) {
-    usersSrv.findAll(req.query).then(users => {
-      res.json(users);
-    }).catch(next);
-  });
+  router.get('/', (req, res, next) => usersSrv.findAll(req.query).then(users => res.json(users)).catch(next));
 
   router.post('/', function (req, res, next) {
     usersSrv.insert(req.body).then(user => {

--- a/test/cli/apps/list.test.js
+++ b/test/cli/apps/list.test.js
@@ -106,7 +106,7 @@ describe('eg apps list', () => {
           done();
         });
       });
-      env.argv = program.parse('apps list -q');
+      env.argv = program.parse('apps list -q -a');
     });
   });
 });

--- a/test/cli/apps/list.test.js
+++ b/test/cli/apps/list.test.js
@@ -26,7 +26,7 @@ describe('eg apps list', () => {
   beforeEach(() => {
     env.prepareHijack();
     return generateUser()
-      .then(user => Promise.all([user, generateApp(user.id), generateApp(user.id)]))
+      .then(user => Promise.all([generateApp(user.id), generateApp(user.id)]))
       .then(([firstApp, secondApp]) => { app1 = firstApp; app2 = secondApp; });
   });
 

--- a/test/cli/users/list.test.js
+++ b/test/cli/users/list.test.js
@@ -142,7 +142,7 @@ describe('eg users list', () => {
           done();
         });
       });
-      env.argv = program.parse('users list');
+      env.argv = program.parse('users list -a');
     });
   });
 });

--- a/test/cli/users/list.test.js
+++ b/test/cli/users/list.test.js
@@ -6,6 +6,28 @@ const namespace = 'express-gateway:users:list';
 const superagent = require('superagent');
 const sinon = require('sinon');
 
+const generateUser = () => adminHelper.admin.users.create({
+  username: idGen.v4(),
+  firstname: 'La',
+  lastname: 'Deeda'
+});
+
+const attachGeneratorEvents = (generator, output, callback) => {
+  generator.once('run', () => {
+    generator.log.error = message => {
+      callback(new Error(message));
+    };
+    generator.stdout = message => {
+      try {
+        const usr = JSON.parse(message);
+        output[usr.username] = true;
+      } catch (e) {
+        output[message] = true;
+      }
+    };
+  });
+};
+
 describe('eg users list', () => {
   let program, env, user1, user2;
 
@@ -17,19 +39,9 @@ describe('eg users list', () => {
 
   beforeEach(() => {
     env.prepareHijack();
-    return adminHelper.admin.users.create({
-      username: idGen.v4(),
-      firstname: 'La',
-      lastname: 'Deeda'
-    }).then(user => {
-      user1 = user;
-      return adminHelper.admin.users.create({
-        username: idGen.v4(),
-        firstname: 'La',
-        lastname: 'Deeda'
-      });
-    }).then(user => {
-      user2 = user;
+    return Promise.all([generateUser(), generateUser()]).then(([firstUser, secondUser]) => {
+      user1 = firstUser;
+      user2 = secondUser;
     });
   });
 
@@ -42,15 +54,7 @@ describe('eg users list', () => {
     env.hijack(namespace, generator => {
       const output = {};
 
-      generator.once('run', () => {
-        generator.log.error = message => {
-          done(new Error(message));
-        };
-        generator.stdout = message => {
-          const usr = JSON.parse(message);
-          output[usr.username] = true;
-        };
-      });
+      attachGeneratorEvents(generator, output, done);
 
       generator.once('end', () => {
         assert.ok(output[user1.username]);
@@ -67,14 +71,7 @@ describe('eg users list', () => {
     env.hijack(namespace, generator => {
       const output = {};
 
-      generator.once('run', () => {
-        generator.log.error = message => {
-          done(new Error(message));
-        };
-        generator.stdout = message => {
-          output[message] = true;
-        };
-      });
+      attachGeneratorEvents(generator, output, done);
 
       generator.once('end', () => {
         assert.ok(output[user1.username]);
@@ -97,14 +94,7 @@ describe('eg users list', () => {
       env.hijack(namespace, generator => {
         const output = {};
 
-        generator.once('run', () => {
-          generator.log.error = message => {
-            done(new Error(message));
-          };
-          generator.stdout = message => {
-            output[message] = true;
-          };
-        });
+        attachGeneratorEvents(generator, output, done);
 
         generator.once('end', () => {
           const args = superagent.Request.prototype.set.lastCall.args;
@@ -123,14 +113,7 @@ describe('eg users list', () => {
       env.hijack(namespace, generator => {
         const output = {};
 
-        generator.once('run', () => {
-          generator.log.error = message => {
-            done(new Error(message));
-          };
-          generator.stdout = message => {
-            output[message] = true;
-          };
-        });
+        attachGeneratorEvents(generator, output, done);
 
         generator.once('end', () => {
           assert.ok(superagent.Request.prototype.set.calledWithMatch(sinon.match('X'), sinon.match('Y')));
@@ -142,6 +125,24 @@ describe('eg users list', () => {
       });
 
       env.argv = program.parse('users list -H "X:Y" -H "A:B" -q');
+    });
+  });
+
+  describe('page navigation', () => {
+    before(() => Promise.all(Array(100).fill().map(generateUser)));
+
+    it('should show all the users when they fill multiple pages', done => {
+      env.hijack(namespace, generator => {
+        const output = {};
+
+        attachGeneratorEvents(generator, output, done);
+
+        generator.once('end', () => {
+          assert.equal(Object.keys(output).length, 102);
+          done();
+        });
+      });
+      env.argv = program.parse('users list');
     });
   });
 });


### PR DESCRIPTION
This PR introduces an additional flag for `eg apps list` and `eg users list` called `-a` or `--all`. When this is provided, the cli will navigate through the paged results from Redis in order to show all the users and not just the first page.

Connect #749 
Closes #749 

P.S: The CLI and the tests for the CLI have *a lot* of copy/paste code that could be removed and reused across the whole part of the system. However doing this now would be a significant amount of time. I still want to do that, but maybe in another iteration.