### PR TITLE
Use array notation for CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY ./lib/config/models /var/lib/eg/models
 
 EXPOSE 8080 9876
 
-CMD node -e "require('express-gateway')().run();"
+CMD ["node", "-e", "require('express-gateway')().run();"]


### PR DESCRIPTION
This PR changes the way we start Express Gateway in the official Docker file. This change has been requested by the guys from the Official Images Docker Program. 

The reason is that the former command allocates an additional /bin/sh process, the latter does not.