### PR TITLE
Add strip path capabilities to Proxy — Connect LunchBadger/general#425

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -11,7 +11,7 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json /usr/src/app/
 RUN npm install
 COPY . /usr/src/app
+
 EXPOSE 8080 9876
-RUN npm install -g express-gateway-plugin-rewrite
 
 CMD [ "node", "lib", "index.js" ]

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -11,7 +11,7 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json /usr/src/app/
 RUN npm install
 COPY . /usr/src/app
-
 EXPOSE 8080 9876
+RUN npm install -g express-gateway-plugin-rewrite
 
 CMD [ "node", "lib", "index.js" ]

--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -7,9 +7,9 @@ module.exports = {
       serviceEndpoint: { type: 'string' },
       changeOrigin: { type: 'boolean', default: true },
       proxyUrl: { type: 'string' },
-      stripUri: { type: 'boolean', default: false },
+      stripPath: { type: 'boolean', default: false },
       strategy: { type: 'string', enum: ['round-robin'], default: 'round-robin' }
     },
-    required: ['serviceEndpoint', 'strategy', 'changeOrigin', 'stripUri']
+    required: ['serviceEndpoint', 'strategy', 'changeOrigin', 'stripPath']
   }
 };

--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -7,8 +7,9 @@ module.exports = {
       serviceEndpoint: { type: 'string' },
       changeOrigin: { type: 'boolean', default: true },
       proxyUrl: { type: 'string' },
+      stripUri: { type: 'boolean', default: false },
       strategy: { type: 'string', enum: ['round-robin'], default: 'round-robin' }
     },
-    required: ['serviceEndpoint', 'strategy', 'changeOrigin']
+    required: ['serviceEndpoint', 'strategy', 'changeOrigin', 'stripUri']
   }
 };

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -77,13 +77,13 @@ module.exports = function (params, config) {
 
   const balancer = createStrategy(strategy, proxyOptions, urls);
 
+  const stripPathFn = params.stripPath ? (req) => { req.url = `${req.params[0]}${req._parsedUrl.search || ''}`; } : () => { };
+
   return function proxyHandler (req, res) {
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
 
-    if (params.stripPath) {
-      req.url = `${req.params[0]}${req._parsedUrl.search || ''}`;
-    }
+    stripPathFn();
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -83,7 +83,7 @@ module.exports = function (params, config) {
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
 
-    stripPathFn();
+    stripPathFn(req);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -82,7 +82,7 @@ module.exports = function (params, config) {
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
 
     if (params.stripPath) {
-      req.url = `${req.params[0]}${req._parsedUrl.search}`;
+      req.url = `${req.params[0]}${req._parsedUrl.search || ''}`;
     }
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -81,6 +81,10 @@ module.exports = function (params, config) {
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
 
+    if (params.stripPath) {
+      req.url = `${req.params[0]}${req._parsedUrl.search}`;
+    }
+
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
 
     proxy.web(req, res, { target, headers, buffer: req.egContext.requestStream });


### PR DESCRIPTION
This PR adds a `stripPath` option to the proxy policy that, when activated, will effectively strip out the matched part from the target url.

This is particularly useful when proxying something to something else and you want to both own the url space as well as preserving the query string parameters and the following path parts when proxying to the selected service endpoint.