### PR TITLE
Validate configuration on API Calls before disk saving

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -118,16 +118,23 @@ class Config {
     const path = this[this.configTypes[type].pathProperty];
     return readFile(path, 'utf8').then(data => {
       let text;
+      let json;
       const isJSON = path.toLowerCase().endsWith('.json');
       if (this.systemConfig && this.systemConfig.preserveStructureOnUpdates && !isJSON) {
         const yawn = new YAWN(data);
-        yawn.json = modifier(yawn.json);
+        json = yawn.json = modifier(yawn.json);
         text = yawn.yaml;
       } else { // js-yaml can handle JSON as well as YAML if no need for structure\comments save
-        const json = yamlOrJson.load(data);
-        const result = modifier(json);
+        const currentJson = yamlOrJson.load(data);
+        const result = json = modifier(currentJson);
         text = yamlOrJson.dump(result);
       }
+      const { isValid, error } = this.configTypes[type].validator(json);
+
+      if (!isValid) {
+        throw new Error(error);
+      }
+
       return writeFile(path, text);
     });
   }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -115,21 +115,22 @@ class Config {
   // due to fragile nature of YAWN it may not work properly in that mode.
   // safe way is to use it in rewrite file mode
   _updateConfigFile (type, modifier) {
-    const path = this[this.configTypes[type].pathProperty];
+    const configType = this.configTypes[type];
+
+    const path = this[configType.pathProperty];
     return readFile(path, 'utf8').then(data => {
       let text;
-      let json;
       const isJSON = path.toLowerCase().endsWith('.json');
       if (this.systemConfig && this.systemConfig.preserveStructureOnUpdates && !isJSON) {
         const yawn = new YAWN(data);
-        json = yawn.json = modifier(yawn.json);
+        yawn.json = modifier(yawn.json);
         text = yawn.yaml;
       } else { // js-yaml can handle JSON as well as YAML if no need for structure\comments save
-        const currentJson = yamlOrJson.load(data);
-        const result = json = modifier(currentJson);
+        const json = yamlOrJson.load(data);
+        const result = modifier(json);
         text = yamlOrJson.dump(result);
       }
-      const { isValid, error } = this.configTypes[type].validator(json);
+      const { isValid, error } = configType.validator(yamlOrJson.load(envReplace(String(text), process.env)));
 
       if (!isValid) {
         throw new Error(error);

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -3,7 +3,6 @@ require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisi
 const util = require('util');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
-const YAWN = require('yawn-yaml/cjs');
 const path = require('path');
 const log = require('../logger').config;
 const chokidar = require('chokidar');
@@ -116,20 +115,13 @@ class Config {
   // safe way is to use it in rewrite file mode
   _updateConfigFile (type, modifier) {
     const configType = this.configTypes[type];
-
     const path = this[configType.pathProperty];
+
     return readFile(path, 'utf8').then(data => {
-      let text;
-      const isJSON = path.toLowerCase().endsWith('.json');
-      if (this.systemConfig && this.systemConfig.preserveStructureOnUpdates && !isJSON) {
-        const yawn = new YAWN(data);
-        yawn.json = modifier(yawn.json);
-        text = yawn.yaml;
-      } else { // js-yaml can handle JSON as well as YAML if no need for structure\comments save
-        const json = yamlOrJson.load(data);
-        const result = modifier(json);
-        text = yamlOrJson.dump(result);
-      }
+      const json = yamlOrJson.load(data);
+      const result = modifier(json);
+      const text = yamlOrJson.dump(result);
+
       const { isValid, error } = configType.validator(yamlOrJson.load(envReplace(String(text), process.env)));
 
       if (!isValid) {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,7 +1,6 @@
 require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
 const fs = require('fs');
 const util = require('util');
-const express = require('express');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const path = require('path');
@@ -133,7 +132,20 @@ class Config {
       }
 
       try {
-        require('../gateway/pipelines').bootstrap({ app: express.Router(), config: { gatewayConfig: candidateConfiguration } });
+        const { policies } = require('../policies');
+        for (const pipelineName in candidateConfiguration.pipelines) {
+          const pipeline = candidateConfiguration.pipelines[pipelineName];
+
+          pipeline.policies.forEach(policy => {
+            const policyName = Object.keys(policy)[0];
+            const policyDefinition = policies[policyName];
+            const { isValid, error } = schemas.validate(policyDefinition.schema.$id, policy[policyName].action || {});
+            if (!isValid) {
+              throw new Error(error);
+            }
+          });
+        }
+
         return writeFile(path, text);
       } catch (err) {
         log.error('Invalid pipelines configuration.', err);

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
 require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
+const fs = require('fs');
 const util = require('util');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,6 +1,7 @@
 require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
 const fs = require('fs');
 const util = require('util');
+const express = require('express');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const path = require('path');
@@ -121,8 +122,9 @@ class Config {
       const json = yamlOrJson.load(data);
       const result = modifier(json);
       const text = yamlOrJson.dump(result);
+      const candidateConfiguration = yamlOrJson.load(envReplace(String(text), process.env));
 
-      const { isValid, error } = configType.validator(yamlOrJson.load(envReplace(String(text), process.env)));
+      const { isValid, error } = configType.validator(candidateConfiguration);
 
       if (!isValid) {
         const e = new Error(error);
@@ -130,7 +132,15 @@ class Config {
         throw e;
       }
 
-      return writeFile(path, text);
+      try {
+        require('../gateway/pipelines').bootstrap({ app: express.Router(), config: { gatewayConfig: candidateConfiguration } });
+        return writeFile(path, text);
+      } catch (err) {
+        log.error('Invalid pipelines configuration.', err);
+        err.code = 'INVALID_CONFIG';
+
+        throw err;
+      }
     });
   }
 }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -110,9 +110,6 @@ class Config {
     return this._updateConfigFile('system', modifier);
   }
 
-  // this function can preserve comments and formatting.
-  // due to fragile nature of YAWN it may not work properly in that mode.
-  // safe way is to use it in rewrite file mode
   _updateConfigFile (type, modifier) {
     const configType = this.configTypes[type];
     const path = this[configType.pathProperty];
@@ -132,6 +129,10 @@ class Config {
       }
 
       try {
+        /*
+          This is really bad. It means we have circular dependencies that's a code smell, no matter what. This needs
+          to be refactored as soon as possible.
+        */
         const { policies } = require('../policies');
         for (const pipelineName in candidateConfiguration.pipelines) {
           const pipeline = candidateConfiguration.pipelines[pipelineName];

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -133,7 +133,9 @@ class Config {
       const { isValid, error } = configType.validator(yamlOrJson.load(envReplace(String(text), process.env)));
 
       if (!isValid) {
-        throw new Error(error);
+        const e = new Error(error);
+        e.code = 'INVALID_CONFIG';
+        throw e;
       }
 
       return writeFile(path, text);

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -37,6 +37,29 @@
           }
         }
       }
+    },
+    "conditionAction": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "action": {
+          "type": "object",
+          "default": {}
+        },
+        "condition": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      }
     }
   },
   "type": "object",
@@ -173,26 +196,19 @@
             "items": [
               {
                 "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "object"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "condition": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      }
+                "maxProperties": 1,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/conditionAction"
                     },
-                    "required": [
-                      "name"
-                    ]
-                  }
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/conditionAction"
+                      }
+                    }
+                  ]
                 }
               }
             ]

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -157,7 +157,11 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
+          "apiEndpoint": {
+            "type": "string"
+          },
           "apiEndpoints": {
+            "minItems": 1,
             "type": "array",
             "items": {
               "type": "string"
@@ -165,6 +169,7 @@
           },
           "policies": {
             "type": "array",
+            "minItems": 1,
             "items": [
               {
                 "type": "object",
@@ -192,7 +197,10 @@
               }
             ]
           }
-        }
+        },
+        "required": [
+          "policies"
+        ]
       }
     }
   }

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -38,6 +38,13 @@ module.exports = function ({ plugins, config } = {}) {
   app.use('/policies', require('./routes/policies')({ config }));
   app.use('/schemas', require('./routes/schemas')());
 
+  app.use((err, req, res, next) => {
+    if (err.code === 'INVALID_CONFIG') {
+      return res.status(422).send(err.message);
+    }
+    next(err);
+  });
+
   if (process.argv.indexOf('--experimental-plugins-api') > -1) {
     app.use('/plugins', require('./routes/plugins')());
   }

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const eventBus = require('../eventBus');
 const swaggerUi = require('swagger-ui-express');
+const express = require('express');
 
 module.exports = function ({ plugins, config } = {}) {
   const cfg = (config || require('../config')).gatewayConfig;
@@ -13,7 +14,7 @@ module.exports = function ({ plugins, config } = {}) {
     return;
   }
   cfg.admin.hostname = cfg.admin.hostname || 'localhost';
-  const express = require('express');
+
   const app = express();
   app.set('x-powered-by', false);
 

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -40,10 +40,11 @@ module.exports = function ({ plugins, config } = {}) {
   app.use('/schemas', require('./routes/schemas')());
 
   app.use((err, req, res, next) => {
+    logger.debug(err.stack);
     if (err.code === 'INVALID_CONFIG') {
       return res.status(422).send(err.message);
     }
-    next(err);
+    res.status(500).send(err.message || 'admin API error');
   });
 
   if (process.argv.indexOf('--experimental-plugins-api') > -1) {
@@ -55,10 +56,6 @@ module.exports = function ({ plugins, config } = {}) {
   swaggerDocument.host = cfg.admin.hostname + ':' + cfg.admin.port;
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
-  app.use((err, req, res, next) => {
-    logger.debug(err.stack);
-    res.status(500).send(err.message || 'admin API error');
-  });
   return new Promise(resolve => {
     const srv = app.listen(cfg.admin.port, cfg.admin.hostname, cfg.admin.backlog, () => {
       const { address, port } = srv.address();

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -21,8 +21,12 @@ describe('REST: pipelines', () => {
   describe('when no pipelines defined', () => {
     beforeEach(() => {
       const initialConfig = {
-        admin: { port: 0 }
+        admin: { port: 0 },
+        apiEndpoints: { api: { host: '*' } },
+        policies: ['proxy', 'terminate'],
+        serviceEndpoints: { backend: { url: 'http://localhost:1010' } }
       };
+
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));
       config.loadGatewayConfig();
       return adminHelper.start({ config });
@@ -31,7 +35,7 @@ describe('REST: pipelines', () => {
     it('should create a new pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
-        policies: [{ proxy: {} }],
+        policies: [{ proxy: { action: { serviceEndpoint: 'backend' } } }],
         customId: idGen.v4() // NOTE: save operation should allow custom props
       };
       return adminHelper.admin.config.pipelines
@@ -50,6 +54,9 @@ describe('REST: pipelines', () => {
     beforeEach(() => {
       const initialConfig = {
         admin: { port: 0 },
+        apiEndpoints: { api: { host: '*' } },
+        serviceEndpoints: { backend: { url: 'http://localhost:1010' } },
+        policies: ['proxy', 'terminate'],
         pipelines: {
           example: { apiEndpoints: ['example'], policies: [{ terminate: {} }] },
           hello: { apiEndpoints: ['hello'], policies: [{ terminate: {} }] }
@@ -64,8 +71,9 @@ describe('REST: pipelines', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{ proxy: {} }]
+        policies: [{ proxy: { action: { serviceEndpoint: 'backend' } } }]
       };
+
       return adminHelper.admin.config.pipelines
         .create('test', testPipeline)
         .then(() => {
@@ -82,7 +90,7 @@ describe('REST: pipelines', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: ['proxy']
+        policies: ['proxy', 'terminate']
       };
       return adminHelper.admin.config.pipelines
         .create('invalid', testPipeline)
@@ -112,7 +120,7 @@ describe('REST: pipelines', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{ proxy: {} }]
+        policies: [{ proxy: { action: { serviceEndpoint: 'backend' } } }]
       };
       return adminHelper.admin.config.pipelines
         .update('example', testPipeline)

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -50,8 +50,8 @@ describe('REST: pipelines', () => {
       const initialConfig = {
         admin: { port: 0 },
         pipelines: {
-          example: { apiEndpoints: ['example'] },
-          hello: { apiEndpoints: ['hello'] }
+          example: { apiEndpoints: ['example'], policies: [{ terminate: {} }] },
+          hello: { apiEndpoints: ['hello'], policies: [{ terminate: {} }] }
         }
       };
       fs.writeFileSync(config.gatewayConfigPath, yaml.dump(initialConfig));

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -30,7 +30,7 @@ describe('REST: pipelines', () => {
     it('should create a new pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
-        policies: [{ action: 'proxy' }],
+        policies: [{ proxy: {} }],
         customId: idGen.v4() // NOTE: save operation should allow custom props
       };
       return adminHelper.admin.config.pipelines
@@ -62,7 +62,7 @@ describe('REST: pipelines', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{ action: 'proxy' }]
+        policies: [{ proxy: {} }]
       };
       return adminHelper.admin.config.pipelines
         .create('test', testPipeline)
@@ -79,7 +79,7 @@ describe('REST: pipelines', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{ action: 'proxy' }]
+        policies: [{ proxy: {} }]
       };
       return adminHelper.admin.config.pipelines
         .update('example', testPipeline)

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -27,6 +27,7 @@ describe('REST: pipelines', () => {
       config.loadGatewayConfig();
       return adminHelper.start({ config });
     });
+
     it('should create a new pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
@@ -58,6 +59,7 @@ describe('REST: pipelines', () => {
       config.loadGatewayConfig();
       return adminHelper.start({ config });
     });
+
     it('should create a new pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
@@ -75,11 +77,27 @@ describe('REST: pipelines', () => {
           should(cfg.pipelines.test).have.property('customId');
         });
     });
-    it('should not create a new pipeline when invalid', () => {
+
+    it('should not create a new pipeline when the general gateway.config is invalid', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
         policies: ['proxy']
+      };
+      return adminHelper.admin.config.pipelines
+        .create('invalid', testPipeline)
+        .catch(() => {
+          const data = fs.readFileSync(config.gatewayConfigPath, 'utf8');
+          const cfg = yaml.load(data);
+          should(cfg.pipelines).not.have.property('invalid');
+        });
+    });
+
+    it('should not create a new pipeline when the a specified policy is invalid', () => {
+      const testPipeline = {
+        apiEndpoints: ['api'],
+        customId: idGen.v4(), // NOTE: save operation should allow custom props
+        policies: [{ proxy: {} }]
       };
       return adminHelper.admin.config.pipelines
         .create('invalid', testPipeline)
@@ -115,6 +133,7 @@ describe('REST: pipelines', () => {
           should(cfg.pipelines.example).not.ok();
         });
     });
+
     it('should show existing pipeline', () => {
       return adminHelper.admin.config.pipelines
         .info('example')
@@ -122,6 +141,7 @@ describe('REST: pipelines', () => {
           should(endpoint.apiEndpoints).be.deepEqual(['example']);
         });
     });
+
     it('should list all pipelines', () => {
       return adminHelper.admin.config.pipelines
         .list()

--- a/test/rest-api/service-endpoint.test.js
+++ b/test/rest-api/service-endpoint.test.js
@@ -29,7 +29,7 @@ describe('REST: service endpoints', () => {
     });
     it('should create a new service endpoint', () => {
       const testEndpoint = {
-        url: 'express-gateway.io',
+        url: 'https://express-gateway.io',
         customId: idGen.v4()
       };
       return adminHelper.admin.config.serviceEndpoints
@@ -58,7 +58,7 @@ describe('REST: service endpoints', () => {
     });
     it('should create a new service endpoint', () => {
       const testEndpoint = {
-        url: 'express-gateway.io',
+        url: 'https://express-gateway.io',
         customId: idGen.v4() // NOTE: save operation should allow custom props
       };
       return adminHelper.admin.config.serviceEndpoints
@@ -74,7 +74,7 @@ describe('REST: service endpoints', () => {
     });
     it('should update existing endpoint', () => {
       const testEndpoint = {
-        url: 'express-gateway.io',
+        url: 'https://express-gateway.io',
         customId: idGen.v4()
       };
       return adminHelper.admin.config.serviceEndpoints


### PR DESCRIPTION
Connect #778
Closes #778

The original intention of this pull request was to simply make sure that, when an Admin API call that is modifying the configuration is done, the validation should be triggered so that we do not persist on disk a broken configuration file.


It then become a dragoon because doing this uncovered several bad things in the codebase that I have decided to fix (see image below)

![image](https://user-images.githubusercontent.com/1416224/43906232-109e8db8-9bf3-11e8-8f05-845f36534dd8.png)

In particular:

1. I've removed the `preserveStructureOnUpdates` support. It's complicating the code for an undocumented flag that nobody is using with a sometimes-broken-parser-dumper.
2. Invoking the generic `gateway.config` file validator before persist the changes
3. Loop through all the proposed policy and invoke their validators one by one before persist the changes to the disk. This is not ideal, it's replicating a logic that's elsewhere already but isolating it in an reasonable amount of time it's tricky. I can do that, though.
4. Adding a `INVALID_CONFIG` error code so that the Admin Express App can detect such condition
6. The Admin API is returning an appropriate status code (`422`)

---

This new behavior made fail some tests because they were just sending strange/random payloads — that wouldn't pass validation. I've fixed these tests and during the thing I discovered that some JSON Schemas in `gateway.config` that I fixed.

Two points in particular:

1. We have got a circular dependency between `policy` and `config`. This is particularly bad, and needs to be fixed as soon as possible.
2. This thing that some parts can be both a single object or an array it's preventing us to use some interesting JSON Schema features. This needs to be fixed as a breaking change, if required.