### PR TITLE
Remove minItems limit for apiEndpoints and policies

### DIFF
--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -184,7 +184,6 @@
             "type": "string"
           },
           "apiEndpoints": {
-            "minItems": 1,
             "type": "array",
             "items": {
               "type": "string"
@@ -192,7 +191,6 @@
           },
           "policies": {
             "type": "array",
-            "minItems": 1,
             "items": [
               {
                 "type": "object",


### PR DESCRIPTION
Connect #788 
Closes #788 

Reverting this strict check until we find the best way to decide when a pipeline is valid or not.