### PR TITLE
Policy can have array steps, validate them

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -140,9 +140,20 @@ class Config {
           pipeline.policies.forEach(policy => {
             const policyName = Object.keys(policy)[0];
             const policyDefinition = policies[policyName];
-            const { isValid, error } = schemas.validate(policyDefinition.schema.$id, policy[policyName].action || {});
-            if (!isValid) {
-              throw new Error(error);
+
+            let policySteps = policy[policyName];
+
+            if (!policySteps) {
+              policySteps = [];
+            } else if (!Array.isArray(policySteps)) {
+              policySteps = [policySteps];
+            }
+
+            for (const step of policySteps) {
+              const { isValid, error } = schemas.validate(policyDefinition.schema.$id, step.action || {});
+              if (!isValid) {
+                throw new Error(error);
+              }
             }
           });
         }

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -116,6 +116,21 @@ describe('REST: pipelines', () => {
         });
     });
 
+    it('should not create a new pipeline when the a specified policy has no condition and action', () => {
+      const testPipeline = {
+        apiEndpoints: ['api'],
+        customId: idGen.v4(), // NOTE: save operation should allow custom props
+        policies: [{ proxy: null }]
+      };
+      return adminHelper.admin.config.pipelines
+        .create('invalid', testPipeline)
+        .catch(() => {
+          const data = fs.readFileSync(config.gatewayConfigPath, 'utf8');
+          const cfg = yaml.load(data);
+          should(cfg.pipelines).not.have.property('invalid');
+        });
+    });
+
     it('should update existing pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],


### PR DESCRIPTION
Follow up #782 

It turns out that a policy can contain a single CA as well as an array of these. This PR accounts this small thing when validating Admin API Calls.