### PR TITLE
Update CircleCI deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2
 jobs:
-  "node-6":
+  node-6:
     docker:
       - image: circleci/node:6-browsers
     working_directory: ~/repo
 
-    steps: &steps
+    steps: &eg-checkout-install
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
@@ -16,32 +16,32 @@ jobs:
             - ./node_modules
       - run: npm test
 
-  "node-8":
+  node-8:
     docker:
       - image: circleci/node:8-browsers
     working_directory: ~/repo
 
-    steps: *steps
+    steps: *eg-checkout-install
 
-  "node-10":
+  node-10:
     docker:
       - image: circleci/node:10-browsers
     working_directory: ~/repo
 
-    steps: *steps
+    steps: *eg-checkout-install
 
-  "node-8-real-redis":
+  node-8-real-redis:
     docker:
       - image: circleci/node:8-browsers
       - image: circleci/redis
     working_directory: ~/repo
     environment:
       - EG_DB_EMULATE: false
-    steps: *steps
+    steps: *eg-checkout-install
 
-  "release-npm":
+  release-npm:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     working_directory: ~/repo
 
     steps:
@@ -49,19 +49,88 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: npm publish
 
-  "release-docker-images":
+  update-docker-repo:
     docker:
-      - image: circleci/node:8
+      - image: node:10-alpine
     working_directory: ~/repo
 
     steps:
-      - run: apk add hub
-      - run: hub clone https://github.com/ExpressGateway/docker-express-gateway.git .
-      - run: npm ci
-      - run: node index.js
-      - run: hub commit -am 'Update Express Gateway Images'
-      - run: hub push
+      - run: &setup_container
+          name: Setup container with Git, Hub, OpenSSH and trust GitHub key
+          command: |-
+            echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+            apk add --update hub git openssh-client
+            mkdir ~/.ssh && ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+            git config --global user.email $GITHUB_EMAIL
+            git config --global user.name $GITHUB_NAME
+      - run:
+          name: Clone the EG's docker repository
+          command: hub clone ExpressGateway/docker-express-gateway .
+      - run:
+          name: Install automation script dependencies
+          command: npm ci
+      - run:
+          name: Generate new Helm and Docker files
+          command: node index.js
+          environment: &environment
+            CIRCLE_TAG: v1.12.0
+            HELM_CHART_VERSION: 0.3.0
+      - run:
+          name: Create new commit with the changes
+          command: hub commit -am "Update Express Gateway Images to $CIRCLE_TAG"
+          environment: *environment
+      - run:
+          name: Push changes to the upstream server
+          command: hub push -f
+      - run:
+          name: Save commit to file
+          command: git rev-parse HEAD > DockerCommit
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - Helmfile
+            - DockerCommit
 
+  update-helm-charts:
+    docker:
+      - image: alpine
+    working_directory: ~/repo
+    steps:
+      - run: *setup_container
+      - run:
+          name: Fork the official helm charts repo
+          command: |-
+            hub clone helm/charts
+            hub fork
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Copy new file in charts
+          command: cp Helmfile ./stable/express-gateway/Chart.yaml
+      - run:
+          name: Commit and push changes
+          command: hub commit -am "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
+
+  update-official-docker-image:
+    docker:
+      - image: alpine
+    working_directory: ~/repo
+    steps:
+      - run: *setup_container
+      - run:
+          name: Fork the official helm charts repo
+          command: |-
+            hub clone docker-library/official-images
+            hub fork
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Put new commit id
+          command: "val=$(cat DockerCommit) && sed -i \"s/GitCommit: .*/GitCommit: $val/g\" library/express-gateway"
+      - run:
+          name: Commit and push changes
+          command: hub add library/express-gateway && hub commit -m "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
+          environment: *environment
   packer:
     docker:
       - image: hashicorp/packer:light
@@ -93,6 +162,16 @@ workflows:
             - node-8
             - node-8-real-redis
             - node-10
-      - release-docker-images: *releaseFilters
-      - packer: *releaseFilters
+      - update-docker-repo:
+          requires:
+            release-npm
+      - update-helm-charts:
+          requires:
+            - update-docker-repo
+      - update-official-docker-image:
+          requires:
+            - update-docker-repo
+      - packer:
+          requires:
+            - release-npm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,13 +72,9 @@ jobs:
       - run:
           name: Generate new Helm and Docker files
           command: node index.js
-          environment: &environment
-            CIRCLE_TAG: v1.12.0
-            HELM_CHART_VERSION: 0.3.0
       - run:
           name: Create new commit with the changes
           command: hub commit -am "Update Express Gateway Images to $CIRCLE_TAG"
-          environment: *environment
       - run:
           name: Push changes to the upstream server
           command: hub push -f
@@ -130,7 +126,6 @@ jobs:
       - run:
           name: Commit and push changes
           command: hub add library/express-gateway && hub commit -m "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
-          environment: *environment
   packer:
     docker:
       - image: hashicorp/packer:light

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  node-6:
+  "node-6":
     docker:
       - image: circleci/node:6-browsers
     working_directory: ~/repo
@@ -16,21 +16,21 @@ jobs:
             - ./node_modules
       - run: npm test
 
-  node-8:
+  "node-8":
     docker:
       - image: circleci/node:8-browsers
     working_directory: ~/repo
 
     steps: *eg-checkout-install
 
-  node-10:
+  "node-10":
     docker:
       - image: circleci/node:10-browsers
     working_directory: ~/repo
 
     steps: *eg-checkout-install
 
-  node-8-real-redis:
+  "node-8-real-redis":
     docker:
       - image: circleci/node:8-browsers
       - image: circleci/redis
@@ -39,17 +39,22 @@ jobs:
       - EG_DB_EMULATE: false
     steps: *eg-checkout-install
 
-  release-npm:
+  "release-npm-docker-image":
     docker:
       - image: circleci/node:10
     working_directory: ~/repo
 
     steps:
       - checkout
+      - setup_remote_docker
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: npm publish
+      - run: "docker login -u $DOCKER_USER --password-stdin $DOCKER_PASSWORD"
+      - run: "docker build -t expressgateway/express-gateway:${CIRCLE_TAG} -t expressgateway/express-gateway:latest --build-arg EG_VERSION=latest ."
+      - run: "docker push expressgateway/express-gateway:${CIRCLE_TAG}"
+      - run: "docker push expressgateway/express-gateway:latest"
 
-  update-docker-repo:
+  "update-docker-repo":
     docker:
       - image: node:10-alpine
     working_directory: ~/repo
@@ -87,7 +92,7 @@ jobs:
             - Helmfile
             - DockerCommit
 
-  update-helm-charts:
+  "update-helm-charts":
     docker:
       - image: alpine
     working_directory: ~/repo
@@ -107,7 +112,7 @@ jobs:
           name: Commit and push changes
           command: hub commit -am "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
 
-  update-official-docker-image:
+  "update-official-docker-image":
     docker:
       - image: alpine
     working_directory: ~/repo
@@ -126,7 +131,8 @@ jobs:
       - run:
           name: Commit and push changes
           command: hub add library/express-gateway && hub commit -m "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
-  packer:
+
+  "packer":
     docker:
       - image: hashicorp/packer:light
     working_directory: ~/repo
@@ -146,7 +152,7 @@ workflows:
       - node-8: *testingFilters
       - node-10: *testingFilters
       - node-8-real-redis: *testingFilters
-      - release-npm: &releaseFilters
+      - release-npm-docker-image: &releaseFilters
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
@@ -157,16 +163,11 @@ workflows:
             - node-8
             - node-8-real-redis
             - node-10
-      - update-docker-repo:
+      - update-docker-repo: &npm-publish-first
           requires:
-            release-npm
-      - update-helm-charts:
-          requires:
-            - update-docker-repo
-      - update-official-docker-image:
+            - release-npm-docker-image
+      - packer: *npm-publish-first
+      - update-helm-charts: &docker-repo-first
           requires:
             - update-docker-repo
-      - packer:
-          requires:
-            - release-npm
-
+      - update-official-docker-image: *docker-repo-first

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,21 +39,25 @@ jobs:
       - EG_DB_EMULATE: false
     steps: *steps
 
-  release:
+  "release-npm":
     docker:
       - image: circleci/node:8
     working_directory: ~/repo
 
     steps:
       - checkout
-      - setup_remote_docker
-      - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: npm publish
-      - run: "docker build -t expressgateway/express-gateway:${CIRCLE_TAG} --build-arg EG_VERSION=latest ."
-      - run: "docker tag expressgateway/express-gateway:${CIRCLE_TAG} expressgateway/express-gateway:latest"
-      - run: "docker push expressgateway/express-gateway:${CIRCLE_TAG}"
-      - run: "docker push expressgateway/express-gateway:latest"
+
+  "release-docker-branch":
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/repo
+
+    steps:
+      - run: git clone https://github.com/ExpressGateway/docker-express-gateway.git .
+      - run: npm ci
+      - run: node index.js
 
   packer:
     docker:
@@ -75,7 +79,7 @@ workflows:
       - node-8: *testingFilters
       - node-10: *testingFilters
       - node-8-real-redis: *testingFilters
-      - release: &releaseFilters
+      - release-npm: &releaseFilters
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
@@ -86,5 +90,6 @@ workflows:
             - node-8
             - node-8-real-redis
             - node-10
+      - release-docker-branch: &releaseFilters
       - packer: *releaseFilters
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,9 @@ jobs:
       - run:
           name: Commit and push changes
           command: hub commit -am "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
+      - run: &createPR
+          name: Create Pull Request
+          command: hub pull-request -m "Update Express Gateway Images to $CIRCLE_TAG"
 
   "update-official-docker-image":
     docker:
@@ -130,7 +133,11 @@ jobs:
           command: "val=$(cat DockerCommit) && sed -i \"s/GitCommit: .*/GitCommit: $val/g\" library/express-gateway"
       - run:
           name: Commit and push changes
-          command: hub add library/express-gateway && hub commit -m "Update Express Gateway Images to $CIRCLE_TAG" && hub push -f -u eg-bot master
+          command: |-
+            hub add library/express-gateway
+            hub commit -m "Update Express Gateway Images to $CIRCLE_TAG"
+            hub push -f -u eg-bot master
+      - run: *createPR
 
   "packer":
     docker:
@@ -170,4 +177,4 @@ workflows:
       - update-helm-charts: &docker-repo-first
           requires:
             - update-docker-repo
-      - update-official-docker-image: *docker-repo-first
+#      - update-official-docker-image: *docker-repo-first

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,15 +49,18 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: npm publish
 
-  "release-docker-branch":
+  "release-docker-images":
     docker:
       - image: circleci/node:8
     working_directory: ~/repo
 
     steps:
-      - run: git clone https://github.com/ExpressGateway/docker-express-gateway.git .
+      - run: apk add hub
+      - run: hub clone https://github.com/ExpressGateway/docker-express-gateway.git .
       - run: npm ci
       - run: node index.js
+      - run: hub commit -am 'Update Express Gateway Images'
+      - run: hub push
 
   packer:
     docker:
@@ -90,6 +93,6 @@ workflows:
             - node-8
             - node-8-real-redis
             - node-10
-      - release-docker-branch: &releaseFilters
+      - release-docker-images: *releaseFilters
       - packer: *releaseFilters
 


### PR DESCRIPTION
This PR is an attempt to automate some of the tasks that I still need to do manually every time I release a new Express Gateway version.

Given the introduction of Helm Charts and the (not yet merged) official Docker Image — there are some new steps to do when releasing EG.

In particular this PR will:

1. Generate new official Docker definition file and new Helm file
2. Clone both the official Official-Images and Helm Charts repository locally under the `eg-bot` user
3. Put the new files in the repo, commit the changes and push them back
4. Create Pull Requests to the official repository for review and merging.

I _think_ it should work, I've been doing a lot of tests and the flow looks reasonable. However I can't really tell until we release. Have fun :trollface: 

Connect #772 
Closes #772 