### PR TITLE
Restore timestamp output for EG

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,13 +1,12 @@
 const { createLogger, format, transports } = require('winston');
-const { combine, colorize, label, printf, splat } = format;
-// TODO: rm LOG_LEVEL and LOG_LEVEL_xxx env vars and configure it system config;
-// system config will provide env vars support
+const { combine, colorize, label, printf, splat, timestamp } = format;
 
 const logFormat = (loggerLabel) => combine(
+  timestamp(),
   splat(),
   colorize(),
   label({ label: loggerLabel }),
-  printf(info => `${info.label} ${info.level}: ${info.message}`)
+  printf(info => `${info.timestamp} ${info.label} ${info.level}: ${info.message}`)
 );
 
 const createLoggerWithLabel = (label) => createLogger({


### PR DESCRIPTION
This PR will restore the support for Timestamp in logs. This feature has been disabled accidentally during the Winston 3.0 migration.