### PR TITLE
Insert JWT credential correctly so that CLI and AdminAPI can catch them

### DIFF
--- a/lib/services/credentials/credential.dao.js
+++ b/lib/services/credentials/credential.dao.js
@@ -111,7 +111,7 @@ dao.insertCredential = function (id, type, credentialObj) {
     return Promise.resolve(null);
   }
   const key = buildIdKey(type, id);
-  if (type === 'key-auth') {
+  if (type === 'key-auth' || type === 'jwt') {
     if (credentialObj.keyId) credentialObj.id = credentialObj.keyId;
     return Promise.all([
       // build relation consumerId -> [key1, key2]
@@ -168,7 +168,7 @@ dao.removeAllCredentials = function (id) {
 dao.getAllCredentials = function (consumerId) {
   const credentialTypes = Object.keys(config.models.credentials.properties);
   const awaitAllPromises = credentialTypes.map(type => {
-    if (type === 'key-auth') { // TODO: replace with separate implementation per type instead of ifs
+    if (type === 'key-auth' || type === 'jwt') { // TODO: replace with separate implementation per type instead of ifs
       return db.smembers(buildIdKey(type, consumerId)).then(keyIds => {
         // 1-* relation, finding all key-auth credentials (consumerid => [KeyId1, KeyId2, ..., KeyIdN])
         return Promise.all(keyIds.map(keyId => this.getCredential(keyId, type)));

--- a/test/cli/credentials/list.test.js
+++ b/test/cli/credentials/list.test.js
@@ -76,6 +76,8 @@ describe('eg credentials list', () => {
           createCredential(user.username, 'oauth2', { secret: 'eg1' }),
           createCredential(user.username, 'key-auth', {}, false),
           createCredential(user.username, 'key-auth', {}, false),
+          createCredential(user.username, 'jwt'),
+          createCredential(user.username, 'jwt', {}, false),
           createCredential(user.username, 'key-auth', {}, false)
         ]);
       })
@@ -213,6 +215,7 @@ describe('eg credentials list', () => {
 
       generator.once('end', () => {
         should(types).have.property('key-auth', 5);
+        should(types).have.property('jwt', 2);
         done();
       });
     });


### PR DESCRIPTION
This PR will make sure that the JWT credentials will be shown correctly when asked through the Admin API.

Unfortunately this is yet another monkey-patch thing, but I have no better options at the moment.

Connect #759 
Closes #759 