### PR TITLE
Correctly return when CLI has been spawned already

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@ logo
 test
 Docker*
 C*.md
+appveyor.yml
+README.md

--- a/bin/environment.js
+++ b/bin/environment.js
@@ -8,7 +8,9 @@ const { executeInScope } = require('./execution-scope');
 exports.bootstrap = (eg, adapter) => {
   const env = yeoman.createEnv();
 
-  executeInScope(env);
+  if (executeInScope(env)) {
+    return;
+  }
 
   env.eg = eg;
 

--- a/bin/execution-scope.js
+++ b/bin/execution-scope.js
@@ -12,13 +12,13 @@ exports.executeInScope = env => {
   rootPath = rootPath ? path.dirname(rootPath) : env.cwd;
 
   if (!rootPath) {
-    return;
+    return false;
   }
 
   const configPath = path.join(rootPath, 'config');
 
   if (!fs.existsSync(configPath)) {
-    return;
+    return false;
   }
 
   if (!process.env.EG_CONFIG_DIR) {
@@ -39,5 +39,8 @@ exports.executeInScope = env => {
       env: childEnv,
       stdio: 'inherit'
     });
+    return true;
   }
+
+  return false;
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -8,6 +8,8 @@ const eg = {
   }
 };
 
-const { program } = require('./environment').bootstrap(eg);
+const bootstraped = require('./environment').bootstrap(eg);
 
-program.parse(process.argv.slice(2));
+if (bootstraped && bootstraped.program) {
+  bootstraped.program.parse(process.argv.slice(2));
+}


### PR DESCRIPTION
This PR solves the annoying bug where the CLI commands get called twice for each command when you have the CLI installed globally as well.

This has been probably introduced when, thanks to ESLint, we replaced some try/catch statements that were not supposed to be there. It turns out these blocks were probably handling that case in a bad way.

I've modified the code to return a flag telling whether the command is coming from a custom spawn or an user call, so that we can return early if the former is happening.

By the way — this is not a great way to handle these situations. NodeJS CLI tools have improved a lot a we should, hopefully one day, leverage these.

Connect #813 
Closes #813 