### PR TITLE
Logs chores

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -62,8 +62,6 @@ class Config {
 
   loadGatewayConfig () { this.loadConfig('gateway'); }
 
-  loadSystemConfig () { this.loadConfig('system'); }
-
   loadModels () {
     ['users.json', 'credentials.json', 'applications.json'].forEach(model => {
       const module = path.resolve(process.env.EG_CONFIG_DIR, 'models', model);
@@ -105,9 +103,6 @@ class Config {
 
   updateGatewayConfig (modifier) {
     return this._updateConfigFile('gateway', modifier);
-  }
-  updateSystemConfig (modifier) {
-    return this._updateConfigFile('system', modifier);
   }
 
   _updateConfigFile (type, modifier) {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -38,7 +38,7 @@ class Config {
     try {
       fs.accessSync(configPath, fs.constants.R_OK);
     } catch (e) {
-      log.info(`Unable to access ${configPath} file. Trying with the json counterpart.`);
+      log.verbose(`Unable to access ${configPath} file. Trying with the json counterpart.`);
       configPath = path.join(process.env.EG_CONFIG_DIR, `${configType.baseFilename}.json`);
     }
 
@@ -70,7 +70,7 @@ class Config {
       const name = path.basename(module, '.json');
       this.models[name] = require(module);
       schemas.register('model', name, this.models[name]);
-      log.info(`Registered schema for ${name} model.`);
+      log.verbose(`Registered schema for ${name} model.`);
     });
   }
 

--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -25,8 +25,7 @@ module.exports = function ({ plugins, config } = {}) {
         const runningApp = httpServer.listen(config.gatewayConfig.http.port, () => {
           const { address, port } = runningApp.address();
 
-          // eslint-disable-next-line no-console
-          console.log(`gateway http server listening on ${address}:${port}`);
+          log.info(`gateway http server listening on ${address}:${port}`);
           eventBus.emit('http-ready', { httpServer: runningApp });
 
           apps.httpApp = runningApp;
@@ -42,8 +41,7 @@ module.exports = function ({ plugins, config } = {}) {
         const runningApp = httpsServer.listen(config.gatewayConfig.https.port, () => {
           const { address, port } = runningApp.address();
 
-          // eslint-disable-next-line no-console
-          console.log(`gateway https server listening on ${address}:${port}`);
+          log.info(`gateway https server listening on ${address}:${port}`);
           eventBus.emit('https-ready', { httpsServer: runningApp });
           apps.httpsApp = runningApp;
           resolve(runningApp);

--- a/lib/gateway/pipelines.js
+++ b/lib/gateway/pipelines.js
@@ -13,7 +13,7 @@ module.exports.bootstrap = function ({ app, config }) {
   const apiEndpointToPipelineMap = {};
 
   for (const name in config.gatewayConfig.pipelines) {
-    log.info(`processing pipeline ${name}`);
+    log.verbose(`processing pipeline ${name}`);
 
     const pipeline = config.gatewayConfig.pipelines[name];
     const router = configurePipeline(pipeline.policies || [], config);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
 const { createLogger, format, transports } = require('winston');
+const chalk = require('chalk').default;
 const { combine, colorize, label, printf, splat, timestamp } = format;
 
 const logFormat = (loggerLabel) => combine(
@@ -6,11 +7,11 @@ const logFormat = (loggerLabel) => combine(
   splat(),
   colorize(),
   label({ label: loggerLabel }),
-  printf(info => `${info.timestamp} ${info.label} ${info.level}: ${info.message}`)
+  printf(info => `${info.timestamp} ${chalk.cyan(info.label)} ${info.level}: ${info.message}`)
 );
 
 const createLoggerWithLabel = (label) => createLogger({
-  level: process.env.LOG_LEVEL_GATEWAY || process.env.LOG_LEVEL || 'warn',
+  level: process.env.LOG_LEVEL || 'info',
   transports: [new transports.Console({})],
   format: logFormat(label)
 });

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -52,7 +52,7 @@ module.exports = function (params, config) {
   const intermediateProxyUrl = process.env.http_proxy || process.env.HTTP_PROXY || params.proxyUrl;
 
   if (intermediateProxyUrl) {
-    logger.info(`using intermediate proxy ${intermediateProxyUrl}`);
+    logger.verbose(`using intermediate proxy ${intermediateProxyUrl}`);
     proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
 

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -59,7 +59,6 @@ module.exports = function ({ plugins, config } = {}) {
   return new Promise(resolve => {
     const srv = app.listen(cfg.admin.port, cfg.admin.hostname, cfg.admin.backlog, () => {
       const { address, port } = srv.address();
-      // eslint-disable-next-line no-console
       logger.info(`admin http server listening on ${address}:${port}`);
       eventBus.emit('admin-ready', { adminServer: srv });
       resolve(srv);

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -10,7 +10,7 @@ module.exports = function ({ plugins, config } = {}) {
   const cfg = (config || require('../config')).gatewayConfig;
 
   if (!cfg.admin || cfg.admin.port === undefined || cfg.admin.port === null) {
-    logger.info('Admin server is not configured, launch canceled');
+    logger.verbose('Admin server is not configured, launch canceled');
     return;
   }
   cfg.admin.hostname = cfg.admin.hostname || 'localhost';
@@ -60,7 +60,7 @@ module.exports = function ({ plugins, config } = {}) {
     const srv = app.listen(cfg.admin.port, cfg.admin.hostname, cfg.admin.backlog, () => {
       const { address, port } = srv.address();
       // eslint-disable-next-line no-console
-      console.log(`admin http server listening on ${address}:${port}`);
+      logger.info(`admin http server listening on ${address}:${port}`);
       eventBus.emit('admin-ready', { adminServer: srv });
       resolve(srv);
     });

--- a/test/e2e/hot-reload.test.js
+++ b/test/e2e/hot-reload.test.js
@@ -144,7 +144,7 @@ describe('hot-reload', () => {
               done();
             });
         });
-        // make config invalid
+
         fs.writeFileSync(testGatewayConfigPath, '{er:t4');
       });
     });

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -147,6 +147,16 @@ describe('REST: pipelines', () => {
         });
     });
 
+    it('should refuse a misconfigured policy in a pipeline', () => {
+      const testPipeline = {
+        apiEndpoints: ['api'],
+        customId: idGen.v4(), // NOTE: save operation should allow custom props
+        policies: [{ jwt: { action: {} } }]
+      };
+
+      return should(adminHelper.admin.config.pipelines.update('example', testPipeline)).be.rejectedWith({ response: { statusCode: 422 } });
+    });
+
     it('should delete existing pipeline', () => {
       return adminHelper.admin.config.pipelines
         .remove('example')


### PR DESCRIPTION
1. Winston 3 has a better default log level `info`. Using that we can avoid using `console.log` in production code (which is not redirectable)
2. Given point 1, update all references in the code to use `verbose` to hide statements that do not matter
3. Give color to log context so we can differentiate between timestamp, context, level and message.
4. It turns out we have different functions that aren't used anywhere that are harming our general test coverage. I've deleted these. They're dealing with system.config reload that we do not support.

I'd love to restate a little bit all the log statements in future. This is a start, at least.

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/1416224/45546363-5b4aef00-b81d-11e8-8406-7f2625b552ee.png">
