### PR TITLE
Fix some parts of dev Dockerfile

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -5,13 +5,13 @@ ENV NODE_ENV production
 # Enable chokidar polling so hot-reload mechanism can work on docker or network volumes
 ENV CHOKIDAR_USEPOLLING true
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json /usr/src/app/
 RUN npm install
-COPY . /usr/src/app
 
 EXPOSE 8080 9876
 
 CMD [ "node", "lib", "index.js" ]
+
+COPY . /usr/src/app


### PR DESCRIPTION
1. Do not manually create work directory, `WORKDIR` does that for you.
2. Put the `COPY` statements at the very bottom so we can leverage caching for all the layers.