### PR TITLE
Remove Node 6 support — connect LunchBadger/general#484

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,5 @@
 version: 2
 jobs:
-  "node-6":
-    docker:
-      - image: circleci/node:6-browsers
-    working_directory: ~/repo
-
-    steps: &eg-checkout-install
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
-      - run: npm test
-
   "node-8":
     docker:
       - image: circleci/node:8-browsers
@@ -159,11 +143,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-6: &testingFilters
+      - node-8: &testingFilters
           filters:
             tags:
               only: /v\d+(\.\d+){2}/
-      - node-8: *testingFilters
       - node-10: *testingFilters
       - node-8-real-redis: *testingFilters
       - release-npm-docker-image:
@@ -173,7 +156,6 @@ workflows:
             branches:
               ignore: /.*/
           requires:
-            - node-6
             - node-8
             - node-8-real-redis
             - node-10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,15 @@ jobs:
       - image: circleci/node:8-browsers
     working_directory: ~/repo
 
-    steps: *eg-checkout-install
+    steps: &eg-checkout-install
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: npm ci
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
 
   "node-10":
     docker:

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,14 +34,6 @@
           "crypto.createDecipher"
         ]
       }
-    ],
-    "node/no-unsupported-features/node-builtins": [
-      "error",
-      {
-        "ignores": [
-          "util.promisify"
-        ]
-      }
     ]
   },
   "root": true

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
-
 const eg = {
   get config () {
     return require('../lib/config');

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,4 +1,3 @@
-require('util.promisify/shim')();
 const fs = require('fs');
 const util = require('util');
 const readFile = util.promisify(fs.readFile);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 require('./eventBus'); // init event bus
-require('util.promisify/shim')(); // NOTE: shim for native node 8.0 uril.promisify
+
 const pluginsLoader = require('./plugins');
 if (require.main === module) {
   const config = require('./config'); // this is to init config before loading servers and plugins

--- a/package-lock.json
+++ b/package-lock.json
@@ -1421,6 +1421,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -1649,6 +1650,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -1661,6 +1663,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.1",
         "is-date-object": "^1.0.1",
@@ -2567,7 +2570,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -2706,7 +2710,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2950,6 +2955,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -3348,7 +3354,8 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -3380,7 +3387,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3539,6 +3547,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -3576,7 +3585,8 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5535,7 +5545,8 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5543,15 +5554,6 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -7796,15 +7798,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "start": "node lib/index.js",
@@ -97,7 +97,6 @@
     "superagent-logger": "^1.1.0",
     "superagent-prefix": "0.0.2",
     "swagger-ui-express": "^3.0.10",
-    "util.promisify": "^1.0.0",
     "uuid": "^3.3.2",
     "uuid62": "^1.0.0",
     "vhost": "3.0.2",


### PR DESCRIPTION
Node 6 is not a thing anymore. Let's remove its support as well as the CI checks and the shims required for the old runtime.

Closes LunchBadger/general#484