### PR TITLE
Add request/response modifier policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,7 @@ jobs:
 
     steps: &eg-checkout-install
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
       - run: npm ci
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
       - run: npm test
 
   "node-10":

--- a/lib/config/gateway.config.yml
+++ b/lib/config/gateway.config.yml
@@ -14,32 +14,13 @@ serviceEndpoints:
     url: 'http://localhost:9876' # btw this is EG admin API
 policies:
   - proxy
-  - modifier
+  - key-auth
 pipelines:
   adminAPI:
     apiEndpoints:
       - api
     policies:
-      - modifier:
-          - action:
-              request:
-                headers:
-                  add:
-                    - name: x-test
-                      value: "'Clark Kent'"
-                body:
-                  add:
-                    - name: x-test
-                      value: "'Clark Kent'"
-              response:
-                headers:
-                  add:
-                    - name: x-test
-                      value: "'Clark Kent'"
-                body:
-                  add:
-                    - name: x-test
-                      value: "'Clark Kent'"
+      # - key-auth: # uncomment to enable key-auth
       - proxy:
           - action:
               serviceEndpoint: backend

--- a/lib/config/gateway.config.yml
+++ b/lib/config/gateway.config.yml
@@ -14,13 +14,32 @@ serviceEndpoints:
     url: 'http://localhost:9876' # btw this is EG admin API
 policies:
   - proxy
-  - key-auth
+  - modifier
 pipelines:
   adminAPI:
     apiEndpoints:
       - api
     policies:
-      # - key-auth: # uncomment to enable key-auth
+      - modifier:
+          - action:
+              request:
+                headers:
+                  add:
+                    - name: x-test
+                      value: "'Clark Kent'"
+                body:
+                  add:
+                    - name: x-test
+                      value: "'Clark Kent'"
+              response:
+                headers:
+                  add:
+                    - name: x-test
+                      value: "'Clark Kent'"
+                body:
+                  add:
+                    - name: x-test
+                      value: "'Clark Kent'"
       - proxy:
           - action:
               serviceEndpoint: backend

--- a/lib/policies/headers/headers.js
+++ b/lib/policies/headers/headers.js
@@ -1,6 +1,8 @@
 const log = require('../../logger').policy;
 
 module.exports = function (params) {
+  log.warn(`The headers policy has been marked as deprecated and will be removed in the next major release. Please
+  consider using the modifier policy to do the same thing`);
   return (req, res, next) => {
     for (const key in params.forwardHeaders) {
       const val = params.forwardHeaders[key];

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -1,0 +1,99 @@
+const jsonParser = require('express').json();
+const urlEncoded = require('express').urlencoded({ extended: true });
+const { PassThrough } = require('stream');
+
+module.exports = {
+  schema: {
+    $id: 'http://express-gateway.io/schemas/policies/body-modifier.json',
+    type: 'object',
+    definitions: {
+      addRemove: {
+        type: 'object',
+        properties: {
+          add: {
+            type: ['array'],
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                value: { type: 'string' }
+              }
+            },
+            default: []
+          },
+          remove: {
+            type: ['array'],
+            items: {
+              type: 'string'
+            },
+            default: []
+          }
+        }
+      }
+    },
+    properties: {
+      request: {
+        type: 'object',
+        properties: {
+          headers: { '$ref': '#/definitions/addRemove' },
+          body: { '$ref': '#/definitions/addRemove' }
+        },
+        response: {
+          type: 'object',
+          properties: {
+            headers: { '$ref': '#/definitions/addRemove' },
+            body: { '$ref': '#/definitions/addRemove' }
+          }
+        }
+      }
+    },
+    policy: params => {
+      const transformObject = (transformSpecs, egContext, obj) => {
+        transformSpecs.add.forEach(addParam => { obj[addParam.name] = egContext.run(addParam.value); });
+        transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; });
+
+        return obj;
+      };
+
+      return (req, res, next) => {
+        if (params.request.body) {
+          jsonParser(req, res, (err) => {
+            if (err) return next(err);
+
+            urlEncoded(req, res, (err) => {
+              if (err) return next(err);
+              const bodyData = JSON.stringify(transformObject(params.request.body, req.egContext, req.body));
+              req.headers['content-length'] = Buffer.byteLength(bodyData);
+              req.egContext.requestStream = new PassThrough();
+              req.egContext.requestStream.write(bodyData);
+            });
+          });
+        }
+
+        if (params.request.headers) {
+          transformObject(params.request.headers, req.egContext, req.headers);
+        }
+
+        if (params.response.headers) {
+          transformObject(params.response.headers, req.egContext, res.headers);
+        }
+
+        if (params.response.body) {
+          const _write = res.write;
+          res.write = (data) => {
+            try {
+              const body = transformObject(params.response.body, req.egContext, JSON.parse(data));
+              const bodyData = JSON.stringify(body);
+
+              res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+              _write.call(res, bodyData);
+            } catch (e) {
+              _write.call(res, data);
+            }
+          };
+        }
+        next();
+      };
+    }
+  }
+};

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -54,19 +54,7 @@ module.exports = {
     };
 
     return (req, res, next) => {
-      if (params.request.body) {
-        jsonParser(req, res, (err) => {
-          if (err) return next(err);
-
-          urlEncoded(req, res, (err) => {
-            if (err) return next(err);
-            const bodyData = JSON.stringify(transformObject(params.request.body, req.egContext, req.body));
-            req.headers['content-length'] = Buffer.byteLength(bodyData);
-            req.egContext.requestStream = new PassThrough();
-            req.egContext.requestStream.write(bodyData);
-          });
-        });
-      }
+      let contentType = 'application/x-www-form-urlencoded';
 
       if (params.request.headers) {
         transformObject(params.request.headers, req.egContext, req.headers);
@@ -95,7 +83,29 @@ module.exports = {
           return _writeHead.call(res, statusCode, statusMessage, headers);
         };
       }
-      next();
+      if (params.request.body) {
+        jsonParser(req, res, (err) => {
+          if (err) return next(err);
+          if (req.body !== {}) contentType = 'application/json';
+
+          urlEncoded(req, res, (err) => {
+            if (req.body === {}) contentType = 'application/json';
+            if (err) return next(err);
+
+            const bodyData = JSON.stringify(transformObject(params.request.body, req.egContext, req.body));
+
+            req.headers['content-length'] = Buffer.byteLength(bodyData);
+            req.headers['content-type'] = contentType;
+
+            req.egContext.requestStream = new PassThrough();
+            req.egContext.requestStream.write(bodyData);
+
+            next();
+          });
+        });
+      } else {
+        next();
+      }
     };
   }
 };

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -86,6 +86,18 @@ module.exports = {
           }
         };
       }
+
+      if (params.response.headers) {
+        const _writeHead = res.writeHead;
+
+        res.writeHead = (statusCode, statusMessage, headers) => {
+          if (!headers) {
+            return _writeHead(statusCode, statusMessage, headers);
+          }
+
+          return _writeHead(statusCode, statusMessage, transformObject(params.response.headers, req.egContext, headers));
+        };
+      }
       next();
     };
   }

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -44,7 +44,7 @@ module.exports = {
   policy: params => {
     const transformObject = (transformSpecs, egContext, obj) => {
       if (transformSpecs.add) {
-        transformSpecs.add.forEach(addParam => { obj[addParam.name] = egContext.run(addParam.value); });
+        Object.keys(transformSpecs.add).forEach(addParam => { obj[addParam] = egContext.run(transformSpecs.add[addParam]); });
       }
       if (transformSpecs.remove) {
         transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; });

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -18,82 +18,76 @@ module.exports = {
                 name: { type: 'string' },
                 value: { type: 'string' }
               }
-            },
-            default: []
+            }
           },
           remove: {
             type: ['array'],
             items: {
               type: 'string'
-            },
-            default: []
+            }
           }
         }
-      }
-    },
-    properties: {
-      request: {
+      },
+      transformSpec: {
         type: 'object',
         properties: {
           headers: { '$ref': '#/definitions/addRemove' },
           body: { '$ref': '#/definitions/addRemove' }
-        },
-        response: {
-          type: 'object',
-          properties: {
-            headers: { '$ref': '#/definitions/addRemove' },
-            body: { '$ref': '#/definitions/addRemove' }
-          }
         }
       }
     },
-    policy: params => {
-      const transformObject = (transformSpecs, egContext, obj) => {
-        transformSpecs.add.forEach(addParam => { obj[addParam.name] = egContext.run(addParam.value); });
-        transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; });
-
-        return obj;
-      };
-
-      return (req, res, next) => {
-        if (params.request.body) {
-          jsonParser(req, res, (err) => {
-            if (err) return next(err);
-
-            urlEncoded(req, res, (err) => {
-              if (err) return next(err);
-              const bodyData = JSON.stringify(transformObject(params.request.body, req.egContext, req.body));
-              req.headers['content-length'] = Buffer.byteLength(bodyData);
-              req.egContext.requestStream = new PassThrough();
-              req.egContext.requestStream.write(bodyData);
-            });
-          });
-        }
-
-        if (params.request.headers) {
-          transformObject(params.request.headers, req.egContext, req.headers);
-        }
-
-        if (params.response.headers) {
-          transformObject(params.response.headers, req.egContext, res.headers);
-        }
-
-        if (params.response.body) {
-          const _write = res.write;
-          res.write = (data) => {
-            try {
-              const body = transformObject(params.response.body, req.egContext, JSON.parse(data));
-              const bodyData = JSON.stringify(body);
-
-              res.setHeader('Content-Length', Buffer.byteLength(bodyData));
-              _write.call(res, bodyData);
-            } catch (e) {
-              _write.call(res, data);
-            }
-          };
-        }
-        next();
-      };
+    properties: {
+      request: { '$ref': '#/definitions/transformSpec' },
+      response: { '$ref': '#/definitions/transformSpec' }
     }
+  },
+  policy: params => {
+    const transformObject = (transformSpecs, egContext, obj) => {
+      if (transformSpecs.add) { transformSpecs.add.forEach(addParam => { obj[addParam.name] = egContext.run(addParam.value); }); }
+
+      if (transformSpecs.remove) { transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; }); }
+
+      return obj;
+    };
+
+    return (req, res, next) => {
+      if (params.request.body) {
+        jsonParser(req, res, (err) => {
+          if (err) return next(err);
+
+          urlEncoded(req, res, (err) => {
+            if (err) return next(err);
+            const bodyData = JSON.stringify(transformObject(params.request.body, req.egContext, req.body));
+            req.headers['content-length'] = Buffer.byteLength(bodyData);
+            req.egContext.requestStream = new PassThrough();
+            req.egContext.requestStream.write(bodyData);
+          });
+        });
+      }
+
+      if (params.request.headers) {
+        transformObject(params.request.headers, req.egContext, req.headers);
+      }
+
+      if (params.response.headers) {
+        transformObject(params.response.headers, req.egContext, res.headers);
+      }
+
+      if (params.response.body) {
+        const _write = res.write;
+        res.write = (data) => {
+          try {
+            const body = transformObject(params.response.body, req.egContext, JSON.parse(data));
+            const bodyData = JSON.stringify(body);
+
+            res.setHeader('Content-Length', Buffer.byteLength(bodyData));
+            _write.call(res, bodyData);
+          } catch (e) {
+            _write.call(res, data);
+          }
+        };
+      }
+      next();
+    };
   }
 };

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -11,14 +11,11 @@ module.exports = {
         type: 'object',
         properties: {
           add: {
-            type: ['array'],
-            items: {
-              type: 'object',
-              properties: {
-                name: { type: 'string' },
-                value: { type: 'string' }
-              }
-            }
+            type: 'object',
+            additionalProperties: {
+              type: ['string', 'number']
+            },
+            minProperties: 1
           },
           remove: {
             type: ['array'],
@@ -26,20 +23,23 @@ module.exports = {
               type: 'string'
             }
           }
-        }
+        },
+        anyOf: [{ required: ['add'] }, { required: ['remove'] }]
       },
       transformSpec: {
         type: 'object',
         properties: {
           headers: { '$ref': '#/definitions/addRemove' },
           body: { '$ref': '#/definitions/addRemove' }
-        }
+        },
+        anyOf: [{ required: ['headers'] }, { required: ['body'] }]
       }
     },
     properties: {
       request: { '$ref': '#/definitions/transformSpec' },
       response: { '$ref': '#/definitions/transformSpec' }
-    }
+    },
+    anyOf: [{ required: ['request'] }, { required: ['response'] }]
   },
   policy: params => {
     const transformObject = (transformSpecs, egContext, obj) => {

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -91,11 +91,8 @@ module.exports = {
         const _writeHead = res.writeHead;
 
         res.writeHead = (statusCode, statusMessage, headers) => {
-          if (!headers) {
-            return _writeHead(statusCode, statusMessage, headers);
-          }
-
-          return _writeHead(statusCode, statusMessage, transformObject(params.response.headers, req.egContext, headers));
+          res._headers = transformObject(params.response.headers, req.egContext, res.getHeaders());
+          return _writeHead.call(res, statusCode, statusMessage, headers);
         };
       }
       next();

--- a/lib/policies/modifier/index.js
+++ b/lib/policies/modifier/index.js
@@ -43,9 +43,12 @@ module.exports = {
   },
   policy: params => {
     const transformObject = (transformSpecs, egContext, obj) => {
-      if (transformSpecs.add) { transformSpecs.add.forEach(addParam => { obj[addParam.name] = egContext.run(addParam.value); }); }
-
-      if (transformSpecs.remove) { transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; }); }
+      if (transformSpecs.add) {
+        transformSpecs.add.forEach(addParam => { obj[addParam.name] = egContext.run(addParam.value); });
+      }
+      if (transformSpecs.remove) {
+        transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; });
+      }
 
       return obj;
     };
@@ -67,10 +70,6 @@ module.exports = {
 
       if (params.request.headers) {
         transformObject(params.request.headers, req.egContext, req.headers);
-      }
-
-      if (params.response.headers) {
-        transformObject(params.response.headers, req.egContext, res.headers);
       }
 
       if (params.response.body) {

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -93,7 +93,6 @@ module.exports = function (params, config) {
     stripPathFn(req);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
-
     proxy.web(req, res, { target, headers, buffer: req.egContext.requestStream });
   };
 

--- a/test/policies/modifier/modifier.test.js
+++ b/test/policies/modifier/modifier.test.js
@@ -22,6 +22,11 @@ describe('@modifier policy', () => {
         if (req.header('r-test')) {
           res.setHeader('r-test', req.header('r-test'));
         }
+
+        if (req.body) {
+          should(req.body).have.property('hello', 'world');
+        }
+
         res.setHeader('x-test', 'hello');
         res.status(200).json(Object.assign({ url: req.url }, req.body));
       });
@@ -38,7 +43,7 @@ describe('@modifier policy', () => {
     });
 
     it('should correctly reshape the request and response', () => {
-      return request(app).get('/').expect(res => {
+      return request(app).get('/').type('json').send({}).expect(res => {
         should(res.body).not.have.property('url');
         should(res.header).not.have.property('x-test');
 
@@ -75,6 +80,12 @@ const setupGateway = () => {
             modifier: [{
               action: {
                 request: {
+                  body: {
+                    add: {
+                      hello: '"world"'
+                    },
+                    remove: ['url']
+                  },
                   headers: {
                     add: {
                       'r-test': '"baffino"'

--- a/test/policies/modifier/modifier.test.js
+++ b/test/policies/modifier/modifier.test.js
@@ -1,0 +1,109 @@
+const request = require('supertest');
+const should = require('should');
+const config = require('../../../lib/config');
+const gateway = require('../../../lib/gateway');
+const { findOpenPortNumbers } = require('../../common/server-helper');
+
+const originalGatewayConfig = config.gatewayConfig;
+
+let backendServerPort;
+
+describe('@modifier policy', () => {
+  let app, backendServer;
+
+  before('start HTTP server', (done) => {
+    findOpenPortNumbers(1).then((ports) => {
+      const express = require('express');
+      const expressApp = express();
+
+      backendServerPort = ports[0];
+
+      expressApp.all('*', express.json(), function (req, res) {
+        if (req.header('r-test')) {
+          res.setHeader('r-test', req.header('r-test'));
+        }
+        res.setHeader('x-test', 'hello');
+        res.status(200).json(Object.assign({ url: req.url }, req.body));
+      });
+
+      backendServer = expressApp.listen(backendServerPort, done);
+    });
+  });
+
+  describe('headers and responses modification', () => {
+    before(() => {
+      return setupGateway().then(apps => {
+        app = apps.app;
+      });
+    });
+
+    it('should correctly reshape the request and response', () => {
+      return request(app).get('/').expect(res => {
+        should(res.body).not.have.property('url');
+        should(res.header).not.have.property('x-test');
+
+        should(res.body).have.property('hello', 'world');
+        should(res.header).have.property('r-test', 'baffino');
+        should(res.header).have.property('res', 'correct');
+      });
+    });
+  });
+
+  after('clean up', (done) => {
+    config.gatewayConfig = originalGatewayConfig;
+    backendServer.close(done);
+  });
+});
+
+const setupGateway = () => {
+  config.gatewayConfig = {
+    http: { port: 0 },
+    apiEndpoints: {
+      test: {}
+    },
+    serviceEndpoints: {
+      backend: {
+        url: `http://localhost:${backendServerPort}`
+      }
+    },
+    policies: ['proxy', 'modifier'],
+    pipelines: {
+      pipeline1: {
+        apiEndpoints: ['test'],
+        policies: [
+          {
+            modifier: [{
+              action: {
+                request: {
+                  headers: {
+                    add: {
+                      'r-test': '"baffino"'
+                    }
+                  }
+                },
+                response: {
+                  body: {
+                    add: {
+                      hello: '"world"'
+                    },
+                    remove: ['url']
+                  },
+                  headers: {
+                    add: {
+                      res: '"correct"'
+                    },
+                    remove: ['x-test']
+                  }
+                }
+              }
+            }]
+          }, {
+            proxy: [{
+              action: { serviceEndpoint: 'backend' }
+            }]
+          }]
+      }
+    }
+  };
+  return gateway();
+};

--- a/test/policies/modifier/modifier.test.js
+++ b/test/policies/modifier/modifier.test.js
@@ -83,8 +83,7 @@ const setupGateway = () => {
                   body: {
                     add: {
                       hello: '"world"'
-                    },
-                    remove: ['url']
+                    }
                   },
                   headers: {
                     add: {


### PR DESCRIPTION
This PR will add a new policy in the core called `modifier` that offers the following features:

1. Modify the request headers before they get sent to the upstream server
2. Modify the request body (if JSON) before they get sent to the upstream server
1. Modify the response headers before they get returned to the client
2. Modify the response body (if JSON) before they get returned to the client

The syntax to use such policy is currently like this:

```yaml
modifier:
- action:
    request:
      headers:
        add:
          r-test: 'baffino'
    response:
      body:
        add:
          hello: 'world'
        remove:
        - url
      headers:
        add:
          res: 'correct'
        remove:
        - x-test
```

Note: the left expression is executed on the `egContext`, so you can do `req.params.otherThing`; in general any evaluable expression will work.

```yaml
add:
  fullname: req.body.name + ' ' + req.body.surname
```


### Outstanding parts
* Missing complete code coverage
* Settle down on policy parameters
* Come up with the right policy name
* Figure out if request/response should be all in the same policy, or split these into two policies (`requestModifier`,`responseModifier`)