### PR TITLE
Add support for invoking third-party Express middlewares at startup

### DIFF
--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -7,7 +7,7 @@ const policies = require('../policies');
 const conditions = require('../conditions');
 const passport = require('passport');
 
-module.exports = function ({ plugins, config } = {}) {
+module.exports = function ({ plugins, config, appInit } = {}) {
   const appPromises = [];
   const apps = {};
   if (plugins && plugins.policies && plugins.policies.length) {
@@ -17,7 +17,7 @@ module.exports = function ({ plugins, config } = {}) {
     });
   }
   config = config || require('../config');
-  const { httpServer, httpsServer } = bootstrap({ plugins, config });
+  const { httpServer, httpsServer } = bootstrap({ plugins, config, appInit });
 
   if (config.gatewayConfig.http && httpServer) {
     appPromises.push(

--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -59,9 +59,13 @@ module.exports = function ({ plugins, config } = {}) {
     });
 };
 
-function bootstrap ({ plugins, config } = {}) {
+function bootstrap ({ plugins, config, appInit } = {}) {
   const app = express();
   app.set('x-powered-by', false);
+
+  if (appInit) {
+    appInit(app);
+  }
 
   let rootRouter;
   // Load all routes from policies

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,11 +17,11 @@ if (require.main === module) {
       return this;
     }
 
-    run () {
+    run (appInit) {
       process.env.EG_CONFIG_DIR = this.configPath || process.env.EG_CONFIG_DIR;
       const config = require('./config'); // this is to init config before loading servers and plugins
       const plugins = pluginsLoader.load({ config });
-      const gateway = require('./gateway')({ plugins, config });
+      const gateway = require('./gateway')({ plugins, config, appInit });
       const admin = require('./rest')({ plugins, config });
 
       return Promise.all([gateway, admin]);


### PR DESCRIPTION
Some middlewares (like https://github.com/roylines/node-epimetheus) require that they are the first middleware added to an Express app instance.

This function allows `express-gateway`'s internal `app` instance to be configured against third-party middleware.