### PR TITLE
Honor content negotiation in 404 responses from gateway

### DIFF
--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -89,7 +89,13 @@ function bootstrap ({ plugins, config } = {}) {
   // 404
   app.use((req, res, next) => {
     if (req.accepts('json')) {
-      res.status(404).json({ error: 'resource not found' });
+      res.setHeader('content-type', 'application/problem+json');
+      res.status(404)
+        .json({
+          type: 'https://express-gateway.io/errors#NOT_FOUND',
+          title: 'Resource not found',
+          status: 404
+        });
     } else {
       next();
     }

--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -86,6 +86,15 @@ function bootstrap ({ plugins, config } = {}) {
     rootRouter(req, res, next);
   });
 
+  // 404
+  app.use((req, res, next) => {
+    if (req.accepts('json')) {
+      res.status(404).json({ error: 'resource not found' });
+    } else {
+      next();
+    }
+  });
+
   eventBus.on('hot-reload', (hotReloadContext) => {
     const oldRootRouter = rootRouter;
     try {

--- a/lib/policies/terminate/terminate.js
+++ b/lib/policies/terminate/terminate.js
@@ -1,3 +1,10 @@
 module.exports = (params) =>
-  (req, res, next) =>
-    res.status(params.statusCode).send(params.message);
+  (req, res, next) => {
+    let payload;
+    if (req.accepts('json')) {
+      payload = { message: params.message };
+    } else {
+      payload = params.message;
+    }
+    res.status(params.statusCode).send(payload);
+  };

--- a/lib/policies/terminate/terminate.js
+++ b/lib/policies/terminate/terminate.js
@@ -1,10 +1,8 @@
 module.exports = (params) =>
   (req, res, next) => {
-    let payload;
     if (req.accepts('json')) {
-      payload = { message: params.message };
+      res.status(params.statusCode).send({ message: params.message });
     } else {
-      payload = params.message;
+      res.status(params.statusCode).send(params.message);
     }
-    res.status(params.statusCode).send(payload);
   };

--- a/test/common/routing.helper.js
+++ b/test/common/routing.helper.js
@@ -17,6 +17,7 @@ module.exports = function () {
     }
 
     testScenario.set('Content-Type', 'application/json');
+    testScenario.set('Accept', 'application/json');
 
     if (testCase.setup.host) {
       testScenario.set('Host', testCase.setup.host);
@@ -69,11 +70,14 @@ module.exports = function () {
       return this.validateError(testCase);
     },
     validateError: (testCase) => {
+      testCase.test = testCase.test || {};
+      // allow tests to override the default content type expected
+      testCase.test.contentType = testCase.test.contentType || 'application/json; charset=utf-8';
       return (done) => {
         const testScenario = prepareScenario(testCase);
         testScenario
           .expect(testCase.test.errorCode)
-          .expect('Content-Type', /text\/html/)
+          .expect('Content-Type', testCase.test.contentType)
           .end((err, res) => { done(err); });
       };
     },

--- a/test/common/routing.helper.js
+++ b/test/common/routing.helper.js
@@ -17,7 +17,11 @@ module.exports = function () {
     }
 
     testScenario.set('Content-Type', 'application/json');
-    testScenario.set('Accept', 'application/json');
+    if (testCase.setup.accept) {
+      testScenario.set('Accept', testCase.setup.accept);
+    } else {
+      testScenario.set('Accept', 'application/json');
+    }
 
     if (testCase.setup.host) {
       testScenario.set('Host', testCase.setup.host);

--- a/test/pipelines/empty.test.js
+++ b/test/pipelines/empty.test.js
@@ -47,6 +47,15 @@ describe('Pipelines', () => {
     it('should return 404', () =>
       supertest(_app)
         .get('/no-clue')
+        .expect('Content-Type', /json/)
+        .expect(404)
+    );
+
+    it('should honor content negotiation', () =>
+      supertest(_app)
+        .get('/no-clue')
+        .set('Accept', 'text/html')
+        .expect('Content-Type', /html/)
         .expect(404)
     );
   });

--- a/test/pipelines/empty.test.js
+++ b/test/pipelines/empty.test.js
@@ -48,7 +48,7 @@ describe('Pipelines', () => {
       supertest(_app)
         .get('/no-clue')
         .expect('Content-Type', /json/)
-        .expect(404)
+        .expect(404, '{"error":"resource not found"}')
     );
 
     it('should honor content negotiation', () =>

--- a/test/pipelines/empty.test.js
+++ b/test/pipelines/empty.test.js
@@ -48,7 +48,7 @@ describe('Pipelines', () => {
       supertest(_app)
         .get('/no-clue')
         .expect('Content-Type', /json/)
-        .expect(404, '{"error":"resource not found"}')
+        .expect(404, { status: 404 })
     );
 
     it('should honor content negotiation', () =>

--- a/test/policies/terminate/terminate.test.js
+++ b/test/policies/terminate/terminate.test.js
@@ -39,4 +39,16 @@ describe('@terminate', () => {
       errorCode: 429
     }
   }));
+
+  it('honors content negotiation: ', helper.validateError({
+    setup: {
+      url: '/',
+      accept: 'text/html'
+    },
+    test: {
+      result: 'test',
+      errorCode: 429,
+      contentType: 'text/html; charset=utf-8'
+    }
+  }));
 });


### PR DESCRIPTION
Regardless of what the client specifies in the `Accept` header, when a 404 is returned from express gateway, the response content type and body is always HTML, which is a little odd since most folks will be using this with JSON based APIs.

Example:

```
curl -vv -H "Host: api.mydomain.com" -H "Content-Type: application/json" -H "Accept: application/json" -d '{"foo":"bar"}' http://localhost:8080/v1/something
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> POST /v1/something HTTP/1.1
> Host: api.mydomain.com
> User-Agent: curl/7.54.0
> Content-Type: application/json
> Accept: application/json
> Content-Length: 51
> 
* upload completely sent off: 51 out of 51 bytes
< HTTP/1.1 404 Not Found
< Content-Security-Policy: default-src 'self'
< X-Content-Type-Options: nosniff
< Content-Type: text/html; charset=utf-8
< Content-Length: 147
< Date: Wed, 02 Jan 2019 14:46:31 GMT
< Connection: keep-alive
< 
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot POST /v1/something</pre>
</body>
</html>
* Connection #0 to host localhost left intact
```

With this change, 404s will now honor JSON requests. If we wanted to add support for XML or something else, that's trivial to add as well.

Note that the version of express-rate-limit that express-gateway currently depends on (2.x) is using `res.format()` to toggle between various response content types, and you can't customize the error response, but the latest version uses `res.send()`, and you could then in theory send custom 404 response bodies, but you'd likely need to change the schema for the rate limit policy to support this. See: https://github.com/nfriedly/express-rate-limit/issues/63.

There may be other areas where eg is blindly returning HTML. I'm happy to address those as well if you know of examples off the top of your head.

Thanks.