### PR TITLE
OAuth2 didnt authenticate if no redirectUri but client provided one.

### DIFF
--- a/lib/policies/oauth2/oauth2-server.js
+++ b/lib/policies/oauth2/oauth2-server.js
@@ -267,7 +267,7 @@ module.exports.authorization = [
   server.authorization((req, done) => {
     return authService.validateConsumer(req.clientID)
       .then(consumer => {
-        if (!consumer || consumer.redirectUri !== req.redirectURI) return done(null, false);
+        if (!consumer || (consumer.redirectUri && consumer.redirectUri !== req.redirectURI)) return done(null, false);
 
         if (!req.scope) {
           return done(null, consumer, req.redirectURI);


### PR DESCRIPTION
I was having trouble authenticating Oauth2, both with google home actions, and the postman app.

I found that by not having a redirecturi which is optional for the user/app in express gateway, and the authenticating app providing one that express-gateway would fail.
The reason for not having the redirect uri set, is that the url given is not known.

This pull request resolves that problem by not testing equality if the user does not have one specified.
