### PR TITLE
Update rate limit policy to set redis expiry inline with windowMs

### DIFF
--- a/lib/policies/rate-limit/rate-limit.js
+++ b/lib/policies/rate-limit/rate-limit.js
@@ -14,7 +14,8 @@ module.exports = (params) => {
   }
   return new RateLimit(Object.assign(params, {
     store: new RedisStore({
-      client: require('../../db')
+      client: require('../../db'),
+      expiry: params.windowMs / 1000
     })
   }));
 };


### PR DESCRIPTION
Redis rate limiter expires by default at 60 seconds. 

Dividing the `windowMs` into seconds and then passing it through to replace the default `expiry: 60` will ensure you get correct rate limiting when storing counters in Redis.