### PR TITLE
fix: replace hostname with host in admin config

### DIFF
--- a/bin/eg-generator.js
+++ b/bin/eg-generator.js
@@ -71,7 +71,7 @@ module.exports = class EgGenerator extends Generator {
       baseURL = systemConfig.cli.url;
     } else if (gatewayConfig && gatewayConfig.admin) {
       const adminConfig = gatewayConfig.admin;
-      const host = adminConfig.host || adminConfig.hostname;
+      const host = adminConfig.host || adminConfig.hostname || 'localhost';
       const port = adminConfig.port || 9876;
 
       baseURL = `http://${host}:${port}`;

--- a/bin/eg-generator.js
+++ b/bin/eg-generator.js
@@ -71,10 +71,10 @@ module.exports = class EgGenerator extends Generator {
       baseURL = systemConfig.cli.url;
     } else if (gatewayConfig && gatewayConfig.admin) {
       const adminConfig = gatewayConfig.admin;
-      const hostname = adminConfig.hostname || 'localhost';
+      const host = adminConfig.host || adminConfig.hostname;
       const port = adminConfig.port || 9876;
 
-      baseURL = `http://${hostname}:${port}`;
+      baseURL = `http://${host}:${port}`;
     }
 
     /*

--- a/bin/generators/gateway/templates/basic/config/gateway.config.yml
+++ b/bin/generators/gateway/templates/basic/config/gateway.config.yml
@@ -2,7 +2,7 @@ http:
   port: 8080
 admin:
   port: 9876
-  hostname: localhost
+  host: localhost
 apiEndpoints:
   # see: http://www.express-gateway.io/docs/configuration/gateway.config.yml/apiEndpoints
 serviceEndpoints:

--- a/bin/generators/gateway/templates/getting-started/config/gateway.config.yml
+++ b/bin/generators/gateway/templates/getting-started/config/gateway.config.yml
@@ -2,7 +2,7 @@ http:
   port: 8080
 admin:
   port: 9876
-  hostname: localhost
+  host: localhost
 apiEndpoints:
   api:
     host: localhost

--- a/lib/config/gateway.config.yml
+++ b/lib/config/gateway.config.yml
@@ -5,7 +5,7 @@ http:
 #   tls: {}
 admin: # remove this section to disable admin API
   port: 9876
-  hostname: localhost # use 0.0.0.0 to listen on all IPv4 interfaces
+  host: localhost # use 0.0.0.0 to listen on all IPv4 interfaces
 apiEndpoints:
   api:
     host: '*'

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -102,136 +102,130 @@
       }
     },
     "admin": {
+      "allOf": [
+        {
+          "properties": {
+            "port": {
+              "type": "number",
+              "default": 9876
+            },
+            "host": {
+              "type": "string"
+            },
+            "hostname": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "port"
+          ]
+        }
+      ]
+    }
+  },
+  "apiEndpoints": {
+    "type": [
+      "object",
+      "null"
+    ],
+    "additionalProperties": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/baseApiEndpoint"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/baseApiEndpoint"
+          }
+        }
+      ]
+    }
+  },
+  "serviceEndpoints": {
+    "type": [
+      "object",
+      "null"
+    ],
+    "additionalProperties": {
       "type": "object",
       "properties": {
-        "port": {
-          "type": "number",
-          "default": 9876
+        "url": {
+          "type": "string",
+          "format": "uri"
         },
-        "host": {
-          "type": "string"
-        },
-        "hostname": {
-          "type": "string"
+        "urls": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "oneOf": [
         {
           "required": [
-            "host"
+            "url"
           ]
         },
         {
           "required": [
-            "hostname"
+            "urls"
           ]
         }
       ]
-    },
-    "apiEndpoints": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/baseApiEndpoint"
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/baseApiEndpoint"
-            }
-          }
-        ]
-      }
-    },
-    "serviceEndpoints": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "urls": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+    }
+  },
+  "policies": {
+    "type": "array",
+    "items": {
+      "type": "string"
+    }
+  },
+  "pipelines": {
+    "type": [
+      "object",
+      "array",
+      "null"
+    ],
+    "additionalProperties": {
+      "type": "object",
+      "properties": {
+        "apiEndpoint": {
+          "type": "string"
         },
-        "oneOf": [
-          {
-            "required": [
-              "url"
-            ]
-          },
-          {
-            "required": [
-              "urls"
-            ]
-          }
-        ]
-      }
-    },
-    "policies": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "pipelines": {
-      "type": [
-        "object",
-        "array",
-        "null"
-      ],
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "apiEndpoint": {
+        "apiEndpoints": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "apiEndpoints": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "policies": {
-            "type": "array",
-            "items": [
-              {
-                "type": "object",
-                "maxProperties": 1,
-                "additionalProperties": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/conditionAction"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/conditionAction"
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
           }
         },
-        "required": [
-          "policies"
-        ]
-      }
+        "policies": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "maxProperties": 1,
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/conditionAction"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/conditionAction"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "policies"
+      ]
     }
   }
 }

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -105,7 +105,8 @@
       "type": "object",
       "properties": {
         "port": {
-          "type": "number"
+          "type": "number",
+          "default": 9876
         },
         "host": {
           "type": "string"

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -107,22 +107,25 @@
         "port": {
           "type": "number"
         },
-        "properties": {
-          "oneOf": [
-            {
-              "host": {
-                "type": "string",
-                "default": "localhost"
-              }
-            },
-            {
-              "hostname": {
-                "type": "string"
-              }
-            }
+        "host": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "host"
+          ]
+        },
+        {
+          "required": [
+            "hostname"
           ]
         }
-      }
+      ]
     },
     "apiEndpoints": {
       "type": [

--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -107,8 +107,20 @@
         "port": {
           "type": "number"
         },
-        "hostname": {
-          "type": "string"
+        "properties": {
+          "oneOf": [
+            {
+              "host": {
+                "type": "string",
+                "default": "localhost"
+              }
+            },
+            {
+              "hostname": {
+                "type": "string"
+              }
+            }
+          ]
         }
       }
     },

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -12,6 +12,8 @@ module.exports = function ({ plugins, config } = {}) {
   if (cfg.admin.hostname) {
     logger.warn('Warning! use of hostname is deprecated in admin section, use host instead');
   }
+
+  // Remove the default in the code when we will not support both properties anymore.
   cfg.admin.host = cfg.admin.hostname || cfg.admin.host || 'localhost';
 
   const app = express();

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -9,7 +9,10 @@ module.exports = function ({ plugins, config } = {}) {
     logger.verbose('Admin server is not configured, launch canceled');
     return;
   }
-  cfg.admin.hostname = cfg.admin.hostname || 'localhost';
+  if (cfg.admin.hostname) {
+    logger.warn('Warning! use of hostname is deprecated in admin section, use host instead');
+  }
+  cfg.admin.host = cfg.admin.hostname || cfg.admin.host || 'localhost';
 
   const app = express();
   app.set('x-powered-by', false);
@@ -48,7 +51,8 @@ module.exports = function ({ plugins, config } = {}) {
   }
 
   return new Promise(resolve => {
-    const srv = app.listen(cfg.admin.port, cfg.admin.hostname, cfg.admin.backlog, () => {
+    const { port, host, backlog } = cfg.admin;
+    const srv = app.listen(port, host, backlog, () => {
       const { address, port } = srv.address();
       logger.info(`admin http server listening on ${address}:${port}`);
       eventBus.emit('admin-ready', { adminServer: srv });


### PR DESCRIPTION
- improves consistency with apiEndpoints config
- generators now use host in admin config
- hostname is still supported, but warning is shown

fixes #432