### PR TITLE
eg cli: header apikey secret gets truncated

### DIFF
--- a/bin/eg-generator.js
+++ b/bin/eg-generator.js
@@ -106,7 +106,7 @@ module.exports = class EgGenerator extends Generator {
     const ArrayHeaders = Array.isArray(headers) ? headers : [headers];
 
     return ArrayHeaders.reduce((prev, header) => {
-      const [headerName, headerValue] = header.split(':');
+      const [headerName, headerValue] = header.split(/:(.+)/);
 
       if (headerValue) {
         prev[headerName] = headerValue;


### PR DESCRIPTION
There is a bug in the eg cli, this example:
`eg users list -H "Authorization:apikey 2YvpwOURTnNB0mDFhOpnxj:08o0ZHLD1pGAIiG61tXc9S`

does not work because the headers in the processHeaders function splits the string by ":" splitting the header into three values, and this piece of code only accepts the first two: `const [headerName, headerValue] = header.split(':');`

which truncates the key secret
the header value sent is `{ Authorization: 'apikey 2YvpwOURTnNB0mDFhOpnxj' }`

the above change only splits the first value` header.split(/:(.+)/)`, getting the correct header with keyid:secret
`{ Authorization: 'apikey 2YvpwOURTnNB0mDFhOpnxj:08o0ZHLD1pGAIiG61tXc9S' }`

without this the eg cli does not work