### PR TITLE
Potential feature - adds a health end point

### DIFF
--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -76,8 +76,12 @@ function bootstrap ({ plugins, config } = {}) {
       conditionEngine.register(cond);
     });
   }
+
+  const router = express.Router();
   app.use(passport.initialize());
-  rootRouter = pipelines.bootstrap({ app: express.Router(), config });
+  rootRouter = pipelines.bootstrap({ app: router, config });
+  addHeatlhEndpoint(router);
+
   app.use((req, res, next) => {
     // rootRouter will process all requests;
     // after hot swap old instance will continue to serve previous requests
@@ -89,7 +93,9 @@ function bootstrap ({ plugins, config } = {}) {
   eventBus.on('hot-reload', (hotReloadContext) => {
     const oldRootRouter = rootRouter;
     try {
-      rootRouter = pipelines.bootstrap({ app: express.Router(), config: hotReloadContext.config });
+      const router = express.Router()
+      rootRouter = pipelines.bootstrap({ app: router, config: hotReloadContext.config });
+      addHeatlhEndpoint(router);
       log.info('hot-reload router completed');
     } catch (err) {
       log.error('Could not hot-reload gateway.config.yml. Configuration is invalid.', err);
@@ -103,3 +109,11 @@ function bootstrap ({ plugins, config } = {}) {
 
   return servers.bootstrap(app);
 }
+
+function addHeatlhEndpoint(router){
+  router.get('/health', (request, response) => {
+    response.status(200);
+    response.send("");
+  });
+}
+


### PR DESCRIPTION
This adds a health end point outside the admin end points, that will always open for health pings (if you secure the admin endpoints), this also survives hot reloads. 

The only issue I find with this,  is /health would have to be a reserved endpoint, so it would not be open for reuse