### PR TITLE
Separete json schemas for req/res policies

### DIFF
--- a/lib/conditions/index.js
+++ b/lib/conditions/index.js
@@ -4,8 +4,8 @@ const schemas = require('../schemas');
 const predefined = require('./predefined');
 const conditions = {};
 
-function register({ name, handler, schema }) {
-  const validate = schemas.register('condition', name, schema);
+function register({ type = 'condition', name, handler, schema }) {
+  const validate = schemas.register(type, name, schema);
 
   conditions[name] = config => {
     const validationResult = validate(config);

--- a/lib/conditions/json-schema.js
+++ b/lib/conditions/json-schema.js
@@ -11,7 +11,7 @@ module.exports = {
       schema: {
         type: 'object',
         description: 'Json schema to validate against.',
-        examples: ['{"type":"string"}']
+        examples: [{ type: 'string' }]
       },
       logErrors: {
         type: 'boolean',

--- a/lib/conditions/predefined.js
+++ b/lib/conditions/predefined.js
@@ -14,6 +14,7 @@ const grabSingle = config => {
 module.exports = [
   {
     name: 'base',
+    type: 'internal',
     schema: {
       $id: 'http://express-gateway.io/schemas/conditions/base.json',
       type: 'object',

--- a/lib/policies/request-transformer/schema.js
+++ b/lib/policies/request-transformer/schema.js
@@ -1,5 +1,5 @@
 module.exports = {
-  $id: 'http://express-gateway.io/schemas/policies/body-modifier.json',
+  $id: 'http://express-gateway.io/schemas/policies/request-transformer.json',
   type: 'object',
   definitions: {
     addRemove: {

--- a/lib/policies/response-transformer/index.js
+++ b/lib/policies/response-transformer/index.js
@@ -1,7 +1,10 @@
 const transformObject = require('../request-transformer/transform-object');
 
 module.exports = {
-  schema: require('../request-transformer/schema'),
+  schema: {
+    ...require('../request-transformer/schema'),
+    $id: 'http://express-gateway.io/schemas/policies/response-transformer.json'
+  },
   policy: params => {
     return (req, res, next) => {
       if (params.body) {


### PR DESCRIPTION
This PR is required to make sure that request and response transformers have their own schemas so that the UI and other tooling can detect them accordingly. Right now, sharing the schema, it's almost impossible to make the correct mapping between Schemas and policies.