### PR TITLE
Assignable user and application IDs

### DIFF
--- a/lib/services/consumers/application.service.js
+++ b/lib/services/consumers/application.service.js
@@ -175,7 +175,7 @@ function validateAndCreateApp (appProperties, userId) {
 
       const baseAppProps = { isActive: 'true', id: uuidv4(), userId };
 
-      const app = Object.assign(appProperties, baseAppProps);
+      const app = Object.assign(baseAppProps, appProperties);
 
       utils.appendCreatedAt(app);
       utils.appendUpdatedAt(app);

--- a/lib/services/consumers/user.service.js
+++ b/lib/services/consumers/user.service.js
@@ -150,7 +150,7 @@ function validateAndCreateUser (_user) {
     .then(function (newUser) {
       const baseUserProps = { isActive: 'true', username: _user.username, id: uuidv4() };
       if (newUser) {
-        user = Object.assign(newUser, baseUserProps);
+        user = Object.assign(baseUserProps, newUser);
       } else user = baseUserProps;
 
       utils.appendCreatedAt(user);

--- a/test/services/users.test.js
+++ b/test/services/users.test.js
@@ -224,6 +224,7 @@ describe('User service tests', () => {
       user = createRandomUserObject();
       return userService.insert(user);
     }).then(newUser => {
+      user = newUser; // update test user
       should.exist(newUser);
       user.id = newUser.id;
     }));


### PR DESCRIPTION
Updated validateAndCreateUser & validateAndCreateApp in user & application services. Changed order of object assign to allow id property to be used if present instead of generating a new uuid.

In my case, I need to integrate with an existing PKI where client_id/secret already exist for our customers. I want to be able to assign IDs to the client application instead of generating new IDs. See the following example:
```
{
  "$id": "http://express-gateway.io/models/applications.json",
  "type": "object",
  "properties": {
    "id": {
      "type": "string"
    },
    "name": {
      "type": "string"
    }
  },
  "required": [
    "id",
    "name"
  ]
}
```
`eg apps create -u <user> -p "name=<name>" -p "id=<id>"`