### PR TITLE
Test: test for proxy policy "hostRewrite" option

### DIFF
--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -93,7 +93,7 @@ module.exports = function (params, config) {
     stripPathFn(req);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
-    proxy.web(req, res, { target: target.href, headers, buffer: req.egContext.requestStream });
+    proxy.web(req, res, { target, headers, buffer: req.egContext.requestStream });
   };
 
   // multiple urls will load balance, defaulting to round-robin

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -93,7 +93,7 @@ module.exports = function (params, config) {
     stripPathFn(req);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
-    proxy.web(req, res, { target, headers, buffer: req.egContext.requestStream });
+    proxy.web(req, res, { target: target.href, headers, buffer: req.egContext.requestStream });
   };
 
   // multiple urls will load balance, defaulting to round-robin


### PR DESCRIPTION
currently "target" option is an object, when http-proxy expects it to be a string