### PR TITLE
Oauth2-introspect change scopes to scope

### DIFF
--- a/lib/policies/oauth2-introspect/oauth2-introspect.js
+++ b/lib/policies/oauth2-introspect/oauth2-introspect.js
@@ -11,7 +11,7 @@ module.exports = function (actionParams) {
     const requestedScopes = req.egContext.apiEndpoint.scopes;
 
     const scopeCheck = (tokenData, done) => {
-      const avaiableScopes = tokenData.scopes ? tokenData.scopes.split(' ') : [];
+      const avaiableScopes = tokenData.scope ? tokenData.scope.split(' ') : [];
 
       if (requestedScopes.every(scope => avaiableScopes.includes(scope))) {
         return done(null, tokenData);

--- a/test/policies/oauth2-introspection/oauth2-introspection.js
+++ b/test/policies/oauth2-introspection/oauth2-introspection.js
@@ -59,7 +59,7 @@ describe('oAuth2 Introspection Policy', () => {
             res.json({ active: true });
           })
           .callsFake(res => {
-            res.json({ active: true, scopes: 'read write' });
+            res.json({ active: true, scope: 'read write' });
           });
 
         introspectEndpointSpy = sinon.spy((req, res) => {


### PR DESCRIPTION
As per https://www.iana.org/assignments/jwt/jwt.xhtml, the currently standard way of defining scopes is through the `scope` key and not `scopes`. In this document `scope` is currently draft which cast some confusion on wheter or not it is standard.

See https://datatracker.ietf.org/doc/draft-ietf-oauth-token-exchange/?include_text=1
```
  scope
      OPTIONAL.  A list of space-delimited, case-sensitive strings, as
      defined in Section 3.3 of [RFC6749], that allow the client to
      specify the desired scope of the requested security token in the
      context of the service or resource where the token will be used.
      The values and associated semantics of scope are service specific
```

RFC7662 define `scope` as the key defining scopes in the introspection response which reinforce the idea that `scope` is more standard than `scopes`.
See https://tools.ietf.org/html/rfc7662 section 2.2
```
   scope
      OPTIONAL.  A JSON string containing a space-separated list of
      scopes associated with this token, in the format described in
      Section 3.3 of OAuth 2.0 [RFC6749].
```

Which brings us to RFC6749 (the oauth2 rfc) which define `scope` as the authorization response. See https://tools.ietf.org/html/rfc6749 section 4.1.1
```
   scope
         OPTIONAL, if identical to the scope requested by the client;
         otherwise, REQUIRED.  The scope of the access token as
         described by Section 3.3.
```

In my opinion, we should keep the `scopes` for backward compatibility unless you know no one is using oauth-introspection. We could also add the ability to specify the "scope" key in the parameters of the plugins and encourage users to use `scope` instead of `scopes`.

What do you think ?