### PR TITLE
fix: ".return" is not a function of "db.del"

### DIFF
--- a/lib/services/authorization-codes/authorization-code.dao.js
+++ b/lib/services/authorization-codes/authorization-code.dao.js
@@ -19,8 +19,8 @@ dao.find = function (criteria) {
       }
       code.expiresAt = parseInt(code.expiresAt);
       if (code.expiresAt <= Date.now()) {
-        return this.remove(criteria.id)
-          .return(null);
+        this.remove(criteria.id);
+        return null;
       }
 
       const isEqual = Object.keys(criteria).every((key) => criteria[key] === code[key]);


### PR DESCRIPTION
Whenever the token expiration code run, this error pops up.
```
{"error":"server_error","error_description":"this.remove(...).return is not a function"}
```