### PR TITLE
Adding `selfHandleResponse` option parameter to Proxy policy

### DIFF
--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -80,6 +80,11 @@ module.exports = {
         type: 'boolean',
         default: false,
         description: 'Adds x-forward headers to the proxied request'
+      },
+      selfHandleResponse: {
+        type: 'boolean',
+        default: false,
+        description: 'Self handles proxy response by sending headers and data through express'            
       }
     },
     required: ['strategy', 'changeOrigin', 'stripPath', 'ignorePath', 'prependPath', 'followRedirects']

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -56,8 +56,48 @@ module.exports = function (params, config) {
     proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
 
-  const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
 
+    proxyOptions.selfHandleResponse = true;
+    
+    const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
+    
+    const passThrough = false;
+    
+    proxy.on('proxyRes', async (proxyRes, req, res, options) => {
+        
+        if(true === passThrough) {
+
+            res.statusCode = proxyRes.statusCode;            
+
+            Object.keys(proxyRes.headers).forEach(h => {
+                res.setHeader(h, proxyRes.headers[h]);
+            });
+            
+            proxyRes.pipe(res);
+        } else {
+        
+            let text = '';
+
+            res.statusCode = proxyRes.statusCode;            
+            
+            Object.keys(proxyRes.headers).forEach(h => {
+                if(h === "transfer-encoding") {
+                    return;
+                }
+                
+                res.setHeader(h, proxyRes.headers[h]);
+            });
+            
+            proxyRes.on("data", chunk => {
+                text += chunk.toString("utf8");
+            });
+            
+            proxyRes.on("end", () => {                
+                res.send(text);
+            })
+        }
+    });
+    
   proxy.on('error', (err, req, res) => {
     logger.warn(err);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -25,7 +25,7 @@ module.exports = function (params, config) {
   }
 
   const proxyOptions = Object.assign({}, clone(params));
-
+    
   if (endpoint.proxyOptions) {
     Object.assign(proxyOptions, clone(endpoint.proxyOptions));
   } if (params.proxyOptions) {
@@ -55,49 +55,35 @@ module.exports = function (params, config) {
     logger.verbose(`using intermediate proxy ${intermediateProxyUrl}`);
     proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
-
-
-    proxyOptions.selfHandleResponse = true;
     
-    const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
-    
-    const passThrough = false;
+  const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
+
+  if(proxyOptions.selfHandleResponse) {
     
     proxy.on('proxyRes', async (proxyRes, req, res, options) => {
         
-        if(true === passThrough) {
+      let responseContents = '';
 
-            res.statusCode = proxyRes.statusCode;            
-
-            Object.keys(proxyRes.headers).forEach(h => {
-                res.setHeader(h, proxyRes.headers[h]);
-            });
+      res.statusCode = proxyRes.statusCode;            
             
-            proxyRes.pipe(res);
-        } else {
-        
-            let text = '';
-
-            res.statusCode = proxyRes.statusCode;            
-            
-            Object.keys(proxyRes.headers).forEach(h => {
-                if(h === "transfer-encoding") {
-                    return;
-                }
-                
-                res.setHeader(h, proxyRes.headers[h]);
-            });
-            
-            proxyRes.on("data", chunk => {
-                text += chunk.toString("utf8");
-            });
-            
-            proxyRes.on("end", () => {                
-                res.send(text);
-            })
+      Object.keys(proxyRes.headers).forEach(h => {
+        if(h === "transfer-encoding") {
+          return;
         }
-    });
-    
+                
+        res.setHeader(h, proxyRes.headers[h]);
+      });
+            
+      proxyRes.on("data", chunk => {
+        responseContents += chunk.toString("utf8");
+      });
+            
+      proxyRes.on("end", () => {                
+        res.send(responseContents);
+      });
+    });        
+  }
+
   proxy.on('error', (err, req, res) => {
     logger.warn(err);
 

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -59,13 +59,13 @@ module.exports = function (params, config) {
   const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
 
   if(proxyOptions.selfHandleResponse) {
-    
+      
     proxy.on('proxyRes', async (proxyRes, req, res, options) => {
         
       let responseContents = '';
 
       res.statusCode = proxyRes.statusCode;            
-            
+        
       Object.keys(proxyRes.headers).forEach(h => {
         if(h === "transfer-encoding") {
           return;
@@ -73,14 +73,25 @@ module.exports = function (params, config) {
                 
         res.setHeader(h, proxyRes.headers[h]);
       });
+        
+      const contentType = proxyRes.headers['content-type'];
+
+      if(/^text\//.test(contentType) || /^application\/.*(json|xml|html|javascript|urlencoded)/.test(contentType)) {
+
+        // TODO: Figure out a better way to detect text encoding in the incoming stream
+        // so we can send() to express (for post processing) or pipe it directly
             
-      proxyRes.on("data", chunk => {
-        responseContents += chunk.toString("utf8");
-      });
+        proxyRes.on("data", chunk => {
+          responseContents += chunk.toString("utf8");
+        });
             
-      proxyRes.on("end", () => {                
-        res.send(responseContents);
-      });
+        proxyRes.on("end", () => {
+          res.send(responseContents);
+        });
+            
+      } else {
+        proxyRes.pipe(res);
+      }
     });        
   }
 
@@ -89,7 +100,7 @@ module.exports = function (params, config) {
 
     if (!res.headersSent) {
       res.status(502).send('Bad gateway.');
-    } else {
+    } else { 
       res.end();
     }
   });
@@ -115,7 +126,6 @@ module.exports = function (params, config) {
   return function proxyHandler (req, res) {
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
-
     stripPathFn(req);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8064,7 +8064,7 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },


### PR DESCRIPTION
Adding `selfHandleResponse` and sending the option to `node-http-proxy` is important to enable processing responses from proxied backends.

Usually `node-http-proxy` pipes the proxied response through existing response stream. This can be disabled by `selfHandleResponse`. I supply an implementation suggestion for sending the proxied response through express `res.send()`.

Plugins might monkey patch this method to effectively intercept and handle express gateway responses. As I do in: https://github.com/josemf/express-gateway-plugin-errors.
