### PR TITLE
Fix stripPath to stop it URL-decoding the path

### DIFF
--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -88,7 +88,16 @@ module.exports = function (params, config) {
 
   const stripPathFn = params.stripPath
     ? req => {
-      req.url = `${req.params[0] || ''}${req._parsedUrl.search || ''}`;
+      const wildcardPos = req.route.path.search(/[:*]/);
+      if (wildcardPos === -1) {
+        // no wildcard, strip the full path. i.e. change URL to / + query string
+        req.url = `/${req._parsedUrl.search || ''}`;
+      } else if (wildcardPos === 0) {
+        // full path is a wildcard match so there's nothing to strip
+      } else {
+        // else strip everything up to the first wildcard, ensuring path still begins with /
+        req.url = `/${req.originalUrl.substring(wildcardPos)}`;
+      }
     } : () => { };
 
   return function proxyHandler(req, res) {

--- a/test/policies/proxy/proxy.test.js
+++ b/test/policies/proxy/proxy.test.js
@@ -301,17 +301,16 @@ describe('@proxy policy', () => {
         .type('json')
         .expect(200, { url: '/something' })
         .end((err, res) => {
-          if (err) done(err)
+          if (err) done(err);
           else {
             request(app)
-            .get('/hello/v1/api/endpointSlashedStar/something')
-            .type('json')
-            .expect(200, { url: '/something' })
-            .end((err, res) => done(err))
+              .get('/hello/v1/api/endpointSlashedStar/something')
+              .type('json')
+              .expect(200, { url: '/something' })
+              .end((err, res) => done(err));
           }
-        })
+        });
     });
-
   });
 });
 

--- a/test/policies/proxy/proxy.test.js
+++ b/test/policies/proxy/proxy.test.js
@@ -229,6 +229,8 @@ describe('@proxy policy', () => {
             http: { port: 0 },
             apiEndpoints: {
               testStar: { path: '/hello/v1/api/endpointStar*' },
+              testStarSlash: { path: '/hello/v1/api/endpointSlashedStar/*' },
+              testTwoStars: { path: '/hello/v1/api/endpointTwoStar/*/then/*' },
               test: { path: '/hello/v1/api/endpoint' }
             },
             serviceEndpoints: {
@@ -239,7 +241,7 @@ describe('@proxy policy', () => {
             policies: ['proxy'],
             pipelines: {
               pipeline1: {
-                apiEndpoints: ['testStar'],
+                apiEndpoints: ['testStar', 'testStarSlash', 'testTwoStars'],
                 policies: [{
                   proxy: [{
                     action: Object.assign({ stripPath: true }, defaultProxyOptions, { serviceEndpoint: 'backend' })
@@ -276,6 +278,40 @@ describe('@proxy policy', () => {
         .type('json')
         .expect(200, { url: '/?a=2&b=3&c=10' })
     );
+
+    it('should be proxied without URL decoding the path', () =>
+      request(app)
+        .get('/hello/v1/api/endpointStar/something/foo%2Fbar/index')
+        .query({ a: 2, b: 3, c: 10 })
+        .type('json')
+        .expect(200, { url: '/something/foo%2Fbar/index?a=2&b=3&c=10' })
+    );
+
+    it('should be proxied stripping path up to first wildcard', () =>
+      request(app)
+        .get('/hello/v1/api/endpointTwoStar/something/foo%2Fbar/then/index')
+        .query({ a: 2, b: 3, c: 10 })
+        .type('json')
+        .expect(200, { url: '/something/foo%2Fbar/then/index?a=2&b=3&c=10' })
+    );
+
+    it('endpoint* and endpoint/* should be equivalent', (done) => {
+      request(app)
+        .get('/hello/v1/api/endpointStar/something')
+        .type('json')
+        .expect(200, { url: '/something' })
+        .end((err, res) => {
+          if (err) done(err)
+          else {
+            request(app)
+            .get('/hello/v1/api/endpointSlashedStar/something')
+            .type('json')
+            .expect(200, { url: '/something' })
+            .end((err, res) => done(err))
+          }
+        })
+    });
+
   });
 });
 


### PR DESCRIPTION
Fixes #963 

Instead of using `req.params[0]` it now strips the `originalUrl` up to the position of the first wildcard placeholder.

For example, when matching `/test/*` with `/test/foo%2Fbar`
    - Before this change, stripped URL is `foo/bar`
    - After this change, stripped URL is `/foo%2Fbar`

This also fixes a situation that could cause the incorrect path to be proxied onwards if there are multiple wildcards.

For example, when matching `/test/:foo/then/:bar` with `/test/foovar/then/barval`
    - Before this change, stripped URL is `fooval`
    - After this change, stripped URL is `/fooval/then/barval`