### PR TITLE
fix: install the current installed version of while executing "eg gateway create"

### DIFF
--- a/bin/generators/gateway/create.js
+++ b/bin/generators/gateway/create.js
@@ -128,7 +128,8 @@ module.exports = class extends eg.Generator {
   }
 
   install () {
-    this.npmInstall(['express-gateway'], { save: true });
+    const { version: installedVersion } = require('../../../package.json');
+    this.npmInstall([`express-gateway@${installedVersion}`], { save: true });
   }
 
   end () {


### PR DESCRIPTION
Fixes: #936 
when you execute the 'eg gateway command', this lets you install the currently installed version of express-gateway.