### PR TITLE
Implemented the passport-jwt secretOrKeyProvider

### DIFF
--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -40,7 +40,7 @@ module.exports = {
         description: 'Value istructing the gateway whether verify the sub against the internal SOC'
       }
     },
-    required: ['jwtExtractor', 'checkCredentialExistence'],
-    oneOf: [{ required: ['secretOrPublicKey'] }, { required: ['secretOrPublicKeyFile'] }]
+    required: ['jwtExtractor', 'checkCredentialExistence']
+    // oneOf: [{ required: ['secretOrPublicKey'] }, { required: ['secretOrPublicKeyFile'] }]
   }
 };

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -5,13 +5,38 @@ const JWTStrategy = require('passport-jwt').Strategy;
 const extractors = require('./extractors');
 const services = require('../../services');
 
+const secretProvider = (request, rawJwtToken, done) => {
+  const JWTPayload = JSON.parse(Buffer.from(rawJwtToken.split('.')[1], 'base64').toString('ascii'));
+
+  if (!JWTPayload.sub) {
+    return done(null, false);
+  }
+
+  services.credential.getCredential(JWTPayload.sub, 'jwt')
+    .then(credential => {
+      if (!credential || !credential.isActive) {
+        throw new Error('CREDENTIAL_NOT_FOUND');
+      }
+      return done(null, credential.keySecret);
+    })
+    .catch((err) => {
+      if (err.message === 'CREDENTIAL_NOT_FOUND') {
+        return done(null, false);
+      }
+
+      return done(err);
+    });
+};
+
 module.exports = function (params) {
   const strategyName = `jwt-${uuid()}`;
   const secretOrKey = params.secretOrPublicKeyFile ? fs.readFileSync(params.secretOrPublicKeyFile) : params.secretOrPublicKey;
   const extractor = extractors[params.jwtExtractor](params.jwtExtractorField);
+  const secretOrKeyProvider = secretOrKey ? false : secretProvider;
 
   passport.use(strategyName, new JWTStrategy({
     secretOrKey,
+    secretOrKeyProvider,
     jwtFromRequest: extractor,
     audience: params.audience,
     issuer: params.issuer
@@ -40,7 +65,6 @@ module.exports = function (params) {
         if (!consumer) {
           return done(null, false);
         }
-
         return done(null, consumer);
       }).catch((err) => {
         if (err.message === 'CREDENTIAL_NOT_FOUND') {
@@ -49,7 +73,6 @@ module.exports = function (params) {
         return done(err);
       });
   }));
-
   params.session = false;
   return function (req, res, next) {
     passport.authenticate(strategyName, params, params.getCommonAuthCallback(req, res, next))(req, res, next);

--- a/test/policies/jwt/jwt.test.js
+++ b/test/policies/jwt/jwt.test.js
@@ -75,6 +75,11 @@ describe('JWT policy', () => {
       jwtExtractor: 'query',
       jwtExtractorField: 'jwtKey'
     }
+  }, {
+    description: 'Secret string',
+    jwtSecret: false,
+    jwtSignOptions: {},
+    actionConfig: {}
   }].forEach((jwtSecretTestCase) => {
     describe(jwtSecretTestCase.description, () => {
       before('setup', () => {
@@ -85,7 +90,10 @@ describe('JWT policy', () => {
             lastname: 'Kent',
             email: 'test@example.com'
           }))
-          .then((user) => credentialService.insertCredential(user.id, 'jwt')).then((credential) => { jwtCredential = credential; })
+          .then((user) => credentialService.insertCredential(user.id, 'jwt')).then((credential) => {
+            jwtCredential = credential;
+            jwtSecretTestCase.jwtSecret = jwtSecretTestCase.jwtSecret === false ? credential.keySecret : jwtSecretTestCase.jwtSecret;
+          })
           .then(() => serverHelper.findOpenPortNumbers(1))
           .then(([port]) => {
             config.gatewayConfig = jwtConfigGet(jwtSecretTestCase.actionConfig, port);

--- a/test/rest-api/pipelines.test.js
+++ b/test/rest-api/pipelines.test.js
@@ -147,14 +147,13 @@ describe('REST: pipelines', () => {
         });
     });
 
-    it('should refuse a misconfigured policy in a pipeline', () => {
+    it('should accept a policy without secret in a pipeline', () => {
       const testPipeline = {
         apiEndpoints: ['api'],
         customId: idGen.v4(), // NOTE: save operation should allow custom props
-        policies: [{ jwt: { action: {} } }]
+        policies: [{ jwt: { action: { checkCredentialExistence: true } } }]
       };
-
-      return should(adminHelper.admin.config.pipelines.update('example', testPipeline)).be.rejectedWith({ response: { statusCode: 422 } });
+      return should(adminHelper.admin.config.pipelines.update('example', testPipeline)).be.ok();
     });
 
     it('should delete existing pipeline', () => {


### PR DESCRIPTION
Hello, hope you are well :) 

In this PR i've implemented the secretOrKeyProvider method of the passport-jwt library.

The problem is, if i have many users, everyone with a jwt credential associated, is impossible to make requests, because jwt policy permit to set only one secret, or only one key file for all the requests, so if i sign every jwt with its secret, the gateway respond unauthorized.

This implementation permit to the jwt policy to check the secret for each user with the JWT credentials set.

So, now if there aren't set the params secretOrPublicKey and the secretOrPublicKeyFile, this check is triggered.

Renny.
