### PR TITLE
add proxy errorAction option to customize proxy error responses

### DIFF
--- a/lib/policies/proxy/index.js
+++ b/lib/policies/proxy/index.js
@@ -80,6 +80,21 @@ module.exports = {
         type: 'boolean',
         default: false,
         description: 'Adds x-forward headers to the proxied request'
+      },
+      errorAction: {
+        type: 'object',
+        description: 'Action to execute when a proxy error occurs',
+        properties: {
+          message: {
+            type: 'string',
+            description: 'Error message returned when a proxy error occurs.'
+          },
+          headers: {
+            type: 'object',
+            description: 'A key-value pair of headers/value to be added to the error response',
+            examples: [{ 'Content-Type': 'application/json' }]
+          }
+        }
       }
     },
     required: ['strategy', 'changeOrigin', 'stripPath', 'ignorePath', 'prependPath', 'followRedirects']

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -67,7 +67,12 @@ module.exports = function (params, config) {
     logger.warn(err);
 
     if (!res.headersSent) {
-      res.status(502).send('Bad gateway.');
+      res.status(502);
+      if (params.errorAction) {
+        res.set(params.errorAction.headers || {}).send(params.errorAction.message || 'Bad gateway.');
+      } else {
+        res.send('Bad gateway.');
+      }
     } else {
       res.end();
     }

--- a/test/policies/proxy/proxy.test.js
+++ b/test/policies/proxy/proxy.test.js
@@ -164,6 +164,45 @@ describe('@proxy policy', () => {
     );
   });
 
+  describe('When errorAction is set', () => {
+    before(() => {
+      return gateway({
+        config: {
+          gatewayConfig: {
+            http: { port: 0 },
+            apiEndpoints: {
+              test: {
+                paths: ['/endpoint']
+              }
+            },
+            serviceEndpoints: {
+              backend: {
+                url: 'http://unavailablehost'
+              }
+            },
+            policies: ['proxy'],
+            pipelines: {
+              pipeline1: {
+                apiEndpoints: ['test'],
+                policies: [{
+                  proxy: [{
+                    action: { serviceEndpoint: 'backend', errorAction: { message: 'Gateway Bad!', headers: { 'Content-Type': 'text/plain' } } }
+                  }]
+                }]
+              }
+            }
+          }
+        }
+      }).then(apps => { app = apps.app; });
+    });
+
+    it('should return 502 with error message', () =>
+      request(app)
+        .get('/endpoint')
+        .expect(502, 'Gateway Bad!')
+    );
+  });
+
   describe('requestStream property', () => {
     before(() => {
       return gateway({


### PR DESCRIPTION
Currently, the proxy policy will just return a text/plain "Bad Gateway." response whenever there's a proxy error, as reported here https://github.com/ExpressGateway/express-gateway/issues/692

This is a proposal of a way to customize error responses, so you can pass an `errorAction` option to modify the response body and headers when the proxy errors.