### PR TITLE
Updated to dockerfile to node 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 LABEL maintainer Vincenzo Chianese, vincenzo@express-gateway.io
 

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Node 8 is now end as of 31st December 2019. Updating to Node 10 which is in support until 30th April 2021.

Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>