### PR TITLE
Added algorithm option to jwt policy

### DIFF
--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -41,6 +41,7 @@ module.exports = {
       },
       algorithms: {
         type: 'array',
+        items: { type: 'string', enum: ['HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512'] },
         description: 'If defined, limits valid jwts to specified algorithms'
       }
     },

--- a/lib/policies/jwt/index.js
+++ b/lib/policies/jwt/index.js
@@ -38,6 +38,10 @@ module.exports = {
         type: 'boolean',
         default: true,
         description: 'Value istructing the gateway whether verify the sub against the internal SOC'
+      },
+      algorithms: {
+        type: 'array',
+        description: 'If defined, limits valid jwts to specified algorithms'
       }
     },
     required: ['jwtExtractor', 'checkCredentialExistence'],

--- a/lib/policies/jwt/jwt.js
+++ b/lib/policies/jwt/jwt.js
@@ -14,7 +14,8 @@ module.exports = function (params) {
     secretOrKey,
     jwtFromRequest: extractor,
     audience: params.audience,
-    issuer: params.issuer
+    issuer: params.issuer,
+    algorithms: params.algorithms
   }, (jwtPayload, done) => {
     if (!jwtPayload) {
       return done(null, false);


### PR DESCRIPTION
Hello,
Express-gateway is fantastic — it has become the backbone of our team’s api architecture. That being said, we have run into one small issue.
Problem: The JWT policy does not currently accept algorithms as an option to specify which algorithms can be used to verify tokens. Under the hood I noticed express-gateway uses `passport-jwt`, which uses `jsonwebtoken`. This is the same package we use. Both `passport-jwt` and `jsonwebtoken` support specifying algorithms. This is a good feature because otherwise jsonwebtoken will allow any algorithm to be used depending on what is decoded via the JWT header. Specifying algorithms allows enforcing of standards across our apis.
Solution: Expose the algorithms option in the JWT policy.
Here is the pr for the docs update: https://github.com/ExpressGateway/express-gateway.io/pull/336