### PR TITLE
OAuth2 introspection cannot identify 'scope' in token

### DIFF
--- a/lib/policies/oauth2-introspect/oauth2-introspect.js
+++ b/lib/policies/oauth2-introspect/oauth2-introspect.js
@@ -13,7 +13,8 @@ module.exports = function (actionParams) {
     const requestedScopes = req.egContext.apiEndpoint.scopes;
 
     const scopeCheck = (tokenData, done) => {
-      const avaiableScopes = tokenData.scopes ? tokenData.scopes.split(' ') : [];
+      const tokenDataScopes = tokenData.scope || tokenData.scopes;
+      const avaiableScopes = tokenDataScopes ? tokenDataScopes.split(' ') : [];
 
       if (requestedScopes.every(scope => avaiableScopes.includes(scope))) {
         return done(null, tokenData);


### PR DESCRIPTION
OAuth2 Introspection policy was only expecting a 'scopes' in OAuth2 provider token response.
Some OAuth2 provider implementations use 'scope' field name causing the token scopes verification to fail.
I've added the possibility to work with OAuth2 providers that use both 'scope' and 'scopes' as name of the scopes field token.