### PR TITLE
Expose response body to response transformer policy.

### DIFF
--- a/lib/policies/request-transformer/transform-object.js
+++ b/lib/policies/request-transformer/transform-object.js
@@ -1,6 +1,7 @@
+const np = require('nested-property');
 module.exports = (transformSpecs, egContext, obj) => {
   if (transformSpecs.add) {
-    Object.keys(transformSpecs.add).forEach(addParam => { obj[addParam] = egContext.run(transformSpecs.add[addParam]); });
+    Object.keys(transformSpecs.add).forEach(addParam => { np.set(obj, addParam, egContext.run(transformSpecs.add[addParam])); });
   }
   if (transformSpecs.remove) {
     transformSpecs.remove.forEach(removeParam => { delete obj[removeParam]; });

--- a/lib/policies/response-transformer/index.js
+++ b/lib/policies/response-transformer/index.js
@@ -11,8 +11,10 @@ module.exports = {
         const _write = res.write;
         res.write = (data) => {
           try {
-            const body = transformObject(params.body, req.egContext, JSON.parse(data));
-            const bodyData = JSON.stringify(body);
+            const originalBody = JSON.parse(data);
+            req.egContext.res.body = originalBody;
+            const newBody = transformObject(params.body, req.egContext, originalBody);
+            const bodyData = JSON.stringify(newBody);
 
             res.setHeader('Content-Length', Buffer.byteLength(bodyData));
             _write.call(res, bodyData);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5681,6 +5681,11 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
+    "nested-property": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
+      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
+    },
     "netmask": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash.flatmap": "^4.5.0",
     "minimatch": "^3.0.4",
+    "nested-property": "^4.0.0",
     "oauth2orize": "^1.11.0",
     "parent-require": "^1.0.0",
     "passport": "^0.4.0",

--- a/test/policies/modifier/modifier.test.js
+++ b/test/policies/modifier/modifier.test.js
@@ -48,6 +48,7 @@ describe('@modifier policy', () => {
         should(res.header).not.have.property('x-test');
 
         should(res.body).have.property('hello', 'world');
+        should(res.body.foo).have.property('url', '/');
         should(res.header).have.property('r-test', 'baffino');
         should(res.header).have.property('res', 'correct');
       });
@@ -59,6 +60,7 @@ describe('@modifier policy', () => {
         should(res.header).not.have.property('x-test');
 
         should(res.body).have.property('hello', 'world');
+        should(res.body.foo).have.property('url', '/');
         should(res.header).have.property('r-test', 'baffino');
         should(res.header).have.property('res', 'correct');
       });
@@ -116,6 +118,14 @@ const setupGateway = () => {
                     res: '"correct"'
                   },
                   remove: ['x-test']
+                }
+              }
+            }, {
+              action: {
+                body: {
+                  add: {
+                    'foo.url': 'res.body.url'
+                  }
                 }
               }
             }]


### PR DESCRIPTION
  - Makes the reponse body accessible as egContext.res.body.
  - Supports setting optionally nested properties in the transformed response body.

Hello maintainers and thanks for taking the time to review this. We needed to be able to transform responses not only by adding and removing properties on the response body, but also by using properties in the original response body and modifying their original values. A simple way to do that was exposing the original response body in the egContext so that it can be referenced in the expressions of the responseTransformer actions. I also wanted to be able to set *nested* properties in the response body.

If you think this runs against the design intent of the original req/res modifier, it would be greatly appreciated if you could suggest an alternative approach to modifying properties within the original response body.

Note that this change only exposes the response body only, and not the request body, but it could be updated to support both if wanted.