### PR TITLE
Add retry mechanism

### DIFF
--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -61,11 +61,29 @@ module.exports = function (params, config) {
     proxyOptions.agent = new ProxyAgent(intermediateProxyUrl);
   }
 
+  const retryCountMap = {};
   const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
+  //when http request suucess,clear map
+  proxy.on('end', (req,res)=>{
+    delete retryCountMap[req.egContext.requestID];
+  });
 
+
+  //retry function
+  const maxAutoRetries = params.maxAutoRetries || 1;
   proxy.on('error', (err, req, res) => {
     logger.warn(err);
 
+    const requestID = req.egContext.requestID;
+    let retryCount = retryCountMap[requestID] || 0;
+    if(retryCount < maxAutoRetries){
+      retryCount++;
+      retryCountMap[requestID] = retryCount;
+      // console.log(`retry count: ${retryCount} `, req.originalUrl);
+      proxyHandler(req, res);
+      return;
+    }
+    delete retryCountMap[requestID];
     if (!res.headersSent) {
       res.status(502).send('Bad gateway.');
     } else {
@@ -100,10 +118,9 @@ module.exports = function (params, config) {
       }
     } : () => { };
 
-  return function proxyHandler(req, res) {
+  function proxyHandler(req, res) {
     const target = balancer.nextTarget();
     const headers = Object.assign({ 'eg-request-id': req.egContext.requestID }, proxyOptions.headers);
-
     stripPathFn(req);
 
     logger.debug(`proxying to ${target.href}, ${req.method} ${req.url}`);
@@ -115,6 +132,7 @@ module.exports = function (params, config) {
         agent: !intermediateProxyUrl ? target.protocol === 'https:' ? httpsAgent : httpAgent : proxyOptions.agent
       });
   };
+  return proxyHandler;
 
   // multiple urls will load balance, defaulting to round-robin
 };

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -63,20 +63,19 @@ module.exports = function (params, config) {
 
   const retryCountMap = {};
   const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
-  //when http request suucess,clear map
-  proxy.on('end', (req,res)=>{
+  // when http request suucess,clear map
+  proxy.on('end', (req, res) => {
     delete retryCountMap[req.egContext.requestID];
   });
 
-
-  //retry function
+  // retry function
   const maxAutoRetries = params.maxAutoRetries || 1;
   proxy.on('error', (err, req, res) => {
     logger.warn(err);
 
     const requestID = req.egContext.requestID;
     let retryCount = retryCountMap[requestID] || 0;
-    if(retryCount < maxAutoRetries){
+    if (retryCount < maxAutoRetries) {
       retryCount++;
       retryCountMap[requestID] = retryCount;
       // console.log(`retry count: ${retryCount} `, req.originalUrl);

--- a/lib/policies/proxy/proxy.js
+++ b/lib/policies/proxy/proxy.js
@@ -63,7 +63,6 @@ module.exports = function (params, config) {
 
   const retryCountMap = {};
   const proxy = httpProxy.createProxyServer(Object.assign(params, proxyOptions));
-  // when http request suucess,clear map
   proxy.on('end', (req, res) => {
     delete retryCountMap[req.egContext.requestID];
   });
@@ -78,7 +77,6 @@ module.exports = function (params, config) {
     if (retryCount < maxAutoRetries) {
       retryCount++;
       retryCountMap[requestID] = retryCount;
-      // console.log(`retry count: ${retryCount} `, req.originalUrl);
       proxyHandler(req, res);
       return;
     }


### PR DESCRIPTION
When the gateway proxy proxy sends a request error, there should be a retry mechanism. The same is true for forwarding including load balancing.
In this way, error 502 caused by socket hang up and connect ECONNREFUSED can be avoided.

maxAutoRetries can be configured in gateway.config.yml. The default is 1. 
such as:
```
      - proxy:
          - action:
              serviceEndpoint: lbsmart
              maxAutoRetries: 1
              changeOrigin: true
```